### PR TITLE
Fixes from bugs I encountered

### DIFF
--- a/bin/repmask_vcf.sh
+++ b/bin/repmask_vcf.sh
@@ -9,6 +9,12 @@ FASTA_FILE=indels.fa
 bcftools view --types indels --include 'ILEN>0' ${VCF} | grep -v "#" | awk '{print(sprintf(">%s\n%s", $3, $5))}' >> ${FASTA_FILE}
 bcftools view --types indels --include 'ILEN<0' ${VCF} | grep -v "#" | awk '{print(sprintf(">%s\n%s", $3, $4))}' >> ${FASTA_FILE}
 
+# verify that indels.fa ids are not longer than 50 characters
+if grep ">" indels.fa | awk 'length > 50' | grep -q .; then
+    echo "variant IDs must be no greater than 50 characters"
+    exit 1
+fi
+
 mkdir repeatmasker_dir
 REPMASK_DIR=repeatmasker_dir
 

--- a/main.nf
+++ b/main.nf
@@ -523,7 +523,7 @@ process merge_VCFs {
 
   script:
   """
-  ls *vcf.gz > vcf.list
+  find . -name "*vcf.gz" > vcf.list
   bcftools merge -l vcf.list > GraffiTE.merged.genotypes.vcf
   bgzip GraffiTE.merged.genotypes.vcf
   tabix -p vcf GraffiTE.merged.genotypes.vcf.gz

--- a/main.nf
+++ b/main.nf
@@ -519,7 +519,7 @@ process merge_VCFs {
   path(pangenome_vcf)
 
   output:
-  path("GraffiTE.merged.genotypes.vcf"), emit: typeref_outputs
+  path("GraffiTE.merged.genotypes.vcf.gz"), emit: typeref_outputs
 
   script:
   """
@@ -533,6 +533,8 @@ process merge_VCFs {
   bgzip pangenome.sorted.vcf
   tabix -p vcf pangenome.sorted.vcf.gz
   bcftools annotate -a pangenome.sorted.vcf.gz -c CHROM,POS,ID,REF,ALT,INFO GraffiTE.merged.genotypes.vcf.gz > GraffiTE.merged.genotypes.vcf
+  rm -f GraffiTE.merged.genotypes.vcf.gz
+  bgzip GraffiTE.merged.genotypes.vcf
   """
 }
 


### PR DESCRIPTION
1. Commit `c04ccd9` - in `bin/repmask_vcf.sh` use `samtools faidx` + `awk` instead of `awk` alone to generate `indels.length`. `awk` alone was missing last seq in `indels.fa` 
2. Commit `a6b622f` - in `main.nf` `merge_VCFs`, use `find` instead of `ls` to generate `vcf.list`. If `ls` config includes colors, will break this step.
3. Commit `a7634fb` - gzip the final GraffiTE merged genotypes to save storage
4. Commit `9b92167` - add check if variant IDs are less than 50 characters, will produce error in `RepeatMasker` if not