### PR TITLE
feat(human): subfamily-level pME filter decoupled from the trusted subset

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@
 - :sparkles: **`--repeat_span_cutoff`** (default `0.80`) exposes this threshold to users.
 - :sparkles: **polyA tail detection:** a new INFO field `polyA=TRUE/FALSE/NA` is added to `pangenome.vcf`. For single-hit TE insertions/deletions (`n_hits=1`), the tool trims any exact case-insensitive TSD suffix/prefix from the variant sequence and scans for an A-rich window (≥8 bp, ≥80% A) anchored to the appropriate end (3' for `+` strand hits, 5' for `C` strand, as polyT). `NA` when `n_hits>1`.
 - :sparkles: **`--svs` input:** a new CSV option to pass per-sample VCFs directly (skipping assembly/long-read alignment and SV discovery). See [Input files](#input-files).
-- :sparkles: **Trusted-subset outputs and presence-absence TSVs:** `3_TSD_search/` now also emits `pangenome.trusted.vcf` (+ `pangenome.trusted.human.vcf` with `--human`) and matching `*.presence-absence*.tsv` tables. `pangenome.vcf` `FILTER` column flags trusted records as `PASS` (`.` otherwise). New params: `--trusted_min_svlen` (default 250), `--trusted_max_ultra_span` (default 0.6), `--human`. See [Trusted subsets and presence-absence TSVs](#trusted-subsets-and-presence-absence-tsvs).
-- :sparkles: **HERV-K (HML-2) insertion classifier (`--human` only):** every HERV-K-overlapping SV is post-classified into one of five hypotheses (null↔solo, truncated proviral, solo↔proviral, null↔proviral, other) using a Bayesian model with literature-informed priors. Adds `INFO/HERVK_CLASS`, `INFO/HERVK_PMAP`, `INFO/HERVK_LAMBDA`, `INFO/HERVK_NU` and per-sample `FORMAT/HERVK_AS` (allelic state per haplotype) to the VCF outputs; appends matching columns to the TSV outputs; emits `hervk_polymorphism_summary.md` with per-class counts, posterior confidence distribution, and polyallelic-site flags. Trusted/human outputs additionally drop low-confidence HERV-K calls (class==`other` or pmap<0.90 by default). Defaults can be overridden via `--hervk_config <file>` (template at `utils/HERVK.config.json`). See [HERV-K (HML-2) insertion classifier](#herv-k-hml-2-insertion-classifier---human-only).
+- :warning: **`--human` no longer derives from the trusted subset (breaking):** the human output is now built directly from `pangenome.vcf` by its own polymorphic-MEI filter and is named **`pangenome.human.vcf`** (was `pangenome.trusted.human.vcf`); `pangenome.trusted.vcf` and `pangenome.presence-absence_trusted.tsv` are **not produced** in `--human` runs. The filter keeps only young subfamilies — `AluY*`, `L1HS`, `SVA_D/E/F`, and the strict HML-2 lineage (`HERVK-int`, `LTR5_Hs`, `LTR5A`, `LTR5B`) — instead of whole TE classes, and admits the `n_hits==2` `HERVK-int`+`SVA` proviral pattern that the `n_hits==1` rule used to discard. Whitelists and thresholds are exposed as params (`--human_alu_ids`, `--human_l1_ids`, `--human_sva_ids`, `--human_hervk_ids`, `--human_min_svlen`, `--human_max_ultra_span`, `--human_ignore_filter`, `--hervk_sva_pair`, `--hervk_pair_max_svlen`). A `human_filter_summary.txt` reporting kept and dropped subfamilies is written next to the VCF. See [The `--human` pME subset](#the---human-pme-subset).
+- :sparkles: **Trusted-subset outputs and presence-absence TSVs:** `3_TSD_search/` now also emits `pangenome.trusted.vcf` (non-`--human` runs) and matching `*.presence-absence*.tsv` tables. `pangenome.vcf` `FILTER` column flags trusted records as `PASS` (`.` otherwise). New params: `--trusted_min_svlen` (default 250), `--trusted_max_ultra_span` (default 0.6), `--human`. See [Trusted subsets and presence-absence TSVs](#trusted-subsets-and-presence-absence-tsvs).
+- :sparkles: **HERV-K (HML-2) insertion classifier (`--human` only):** every HERV-K-overlapping SV is post-classified into one of five hypotheses (null↔solo, truncated proviral, solo↔proviral, null↔proviral, other) using a Bayesian model with literature-informed priors. Adds `INFO/HERVK_CLASS`, `INFO/HERVK_PMAP`, `INFO/HERVK_LAMBDA`, `INFO/HERVK_NU` and per-sample `FORMAT/HERVK_AS` (allelic state per haplotype) to the VCF outputs; appends matching columns to the TSV outputs; emits `hervk_polymorphism_summary.md` with per-class counts, posterior confidence distribution, and polyallelic-site flags. The human output additionally drops low-confidence HERV-K calls (class==`other` or pmap<0.90 by default). Defaults can be overridden via `--hervk_config <file>` (template at `utils/HERVK.config.json`). See [HERV-K (HML-2) insertion classifier](#herv-k-hml-2-insertion-classifier---human-only).
 - :wrench: **`--mammal` discontinued:** the option is removed. L1 5' inversion detection and SVA VNTR-only handling are now **always on** and systematically reported for all runs.
 - :wrench: **L1 5' inversion reported as `INFO/L1_5PINV`:** the old `mam_filter_1=5P_INV` flag is replaced by `L1_5PINV`, whose value is the RepeatMasker hit ID(s) of the L1 fragment flagged (or `None`). Detection rule: a LINE/L1 with two fragments sharing the same hit ID but opposite strands (`C,+`), i.e. the twin-priming signature.
 - :wrench: **SVA VNTR-only reclassified:** insertions whose RepeatMasker hit falls entirely within the VNTR region of an SVA consensus are reclassified from `Retroposon/SVA` to `Simple_repeat` (and the family name is suffixed accordingly). This prevents VNTR-only length polymorphisms from being mistakenly counted as SVA MEI. The old `mam_filter_2=SVA_VNTR` field is removed.
@@ -379,7 +380,13 @@ AND (always required)
 - `--repeat_span_cutoff`: minimum fraction of a variant that must be covered by the non-redundant union of RepeatMasker TE hits and ULTRA tandem repeats (`INFO/total_repeat_span`) to be kept in the pangenome VCF. Default `0.80`.
 - `--trusted_min_svlen`: minimum absolute SV length (bp) for a variant to be part of the "trusted" subset. Default `250`. See [Trusted subsets and presence-absence TSVs](#trusted-subsets-and-presence-absence-tsvs).
 - `--trusted_max_ultra_span`: maximum `ULTRA_TR_span` allowed for a variant to be part of the "trusted" subset (filters out variants dominated by tandem repeats, which are more likely to be length polymorphisms than true MEI). Default `0.6`.
-- `--human`: `true` or `false`. When `true`, also emit `pangenome.trusted.human.vcf` and `pangenome.presence-absence_human.tsv`, restricted to the main human MEI classes (LINE/L1, SINE/Alu, Retroposon/SVA, SVA-VNTR as Simple_repeat, LTR/HERVK). In addition, the HERV-K (HML-2) classifier is run on every HERV-K-overlapping SV: it adds `INFO/HERVK_CLASS`, `INFO/HERVK_PMAP`, `INFO/HERVK_LAMBDA`, `INFO/HERVK_NU` and a per-sample `FORMAT/HERVK_AS` field, drops low-confidence HERV-K calls from the trusted/human outputs, and writes `hervk_polymorphism_summary.md` to `3_TSD_search/`. See [HERV-K (HML-2) insertion classifier](#herv-k-hml-2-insertion-classifier---human-only). Default `false`.
+- `--human`: `true` or `false`. When `true`, GraffiTE emits `pangenome.human.vcf` and `pangenome.presence-absence_human.tsv` **instead of** the trusted subset, filtered for polymorphic mobile elements: young subfamilies only (`AluY*`, `L1HS`, `SVA_D/E/F`, HML-2), a single RepeatMasker hit, plus the `HERVK-int`+`SVA` proviral exception. In addition, the HERV-K (HML-2) classifier is run on every HERV-K-overlapping SV: it adds `INFO/HERVK_CLASS`, `INFO/HERVK_PMAP`, `INFO/HERVK_LAMBDA`, `INFO/HERVK_NU` and a per-sample `FORMAT/HERVK_AS` field, drops low-confidence HERV-K calls from the human output, and writes `hervk_polymorphism_summary.md` to `3_TSD_search/`. See [The `--human` pME subset](#the---human-pme-subset) and [HERV-K (HML-2) insertion classifier](#herv-k-hml-2-insertion-classifier---human-only). Default `false`.
+- `--human_alu_ids`, `--human_l1_ids`, `--human_sva_ids`, `--human_hervk_ids`: comma-separated lists of regexes matched against `INFO/repeat_ids` to define the retained subfamilies. Defaults `^AluY`, `^L1HS`, `^SVA_[DEF]`, `^HERVK-int,^LTR5_Hs,^LTR5A,^LTR5B`. Setting one to the empty string keeps its whole class. Only used when `--human`. See [The `--human` pME subset](#the---human-pme-subset).
+- `--human_min_svlen`: minimum absolute SV length (bp) for `pangenome.human.vcf`. Default `250` (independent of `--trusted_min_svlen`; lower it to keep short 5'-truncated Alu insertions and short SVA-VNTR expansions).
+- `--human_max_ultra_span`: maximum `ULTRA_TR_span` for `pangenome.human.vcf`, waived for `Simple_repeat` (SVA-VNTR) records. Default `0.6`.
+- `--human_ignore_filter`: if `true`, do not require `FILTER=="PASS"` for the human subset. Default `false`.
+- `--hervk_sva_pair`: if `true`, admit `n_hits==2` records annotated `HERVK-int` + SVA into the human subset. These are HML-2 proviral SVs where RepeatMasker assigns part of the LTR to SVA (`SVA_A`/`LTR5_Hs` homology); they would otherwise be lost to the single-hit rule. Default `true`.
+- `--hervk_pair_max_svlen`: maximum `|SVLEN|` for the above. Default `10500` (a complete proviral element is 9472 bp).
 - `--hervk_config`: path to an optional JSON config (template at `utils/HERVK.config.json`) overriding HERV-K classifier defaults (priors, sigmas, H_T window, SVA-mimic window, strict pmap threshold, polyallelic window). Only used when `--human`. Default `null` (use script defaults).
 - `--cores`: global CPU parameter. Will apply the chosen integer to all multi-threaded processes. See [here](#changing-the-number-of-cpus-and-memory-required-by-each-step) for more customization.
 - `--mammal`: **discontinued in v1.1** — accepting the flag is harmless but it no longer gates behavior. The two filters it used to enable (LINE1 5' inversion detection, SVA VNTR-only reclassification) are now always on. See [L1 5' inversion](#l1-5-inversion) for details.
@@ -505,11 +512,12 @@ OUTPUT_FOLDER/
 │       └── OneCode_LTR.dic
 ├── 3_TSD_search
 │   ├── pangenome.vcf
-│   ├── pangenome.trusted.vcf
-│   ├── pangenome.trusted.human.vcf            (only with --human)
+│   ├── pangenome.trusted.vcf                  (not with --human)
+│   ├── pangenome.human.vcf                    (only with --human)
 │   ├── pangenome.presence-absence.tsv
-│   ├── pangenome.presence-absence_trusted.tsv
+│   ├── pangenome.presence-absence_trusted.tsv (not with --human)
 │   ├── pangenome.presence-absence_human.tsv   (only with --human)
+│   ├── human_filter_summary.txt               (only with --human)
 │   ├── hervk_polymorphism_summary.md          (only with --human)
 │   ├── TSD_full_log.txt
 │   └── TSD_summary.txt
@@ -532,9 +540,10 @@ OUTPUT_FOLDER/
       - `onecode.log`: log file for `OneCodeToFindThemAll` process.
 - `3_TSD_Search/` (see [TSD section](#tsd-module))
    - `pangenome.vcf` — final VCF containing **all** retained repeat variants and annotations (with TSD if passing the TSD filters). The VCF `FILTER` column now encodes the trusted-subset classification: `PASS` = satisfies the trusted criteria (see [Trusted subsets and presence-absence TSVs](#trusted-subsets-and-presence-absence-tsvs)); `.` = kept but does not meet the trusted criteria. This file is used later by `Pangenie`, `Giraffe` or `graphAligner` to build the genome-graph for genotyping. Can be re-used for genotyping only with `--graffite_vcf pangenome.vcf`.
-   - `pangenome.trusted.vcf` — subset of `pangenome.vcf` where `FILTER=PASS` (trusted MEI candidates only).
-   - `pangenome.trusted.human.vcf` — only produced when `--human` is set. Trusted subset further restricted to `matching_classes` ∈ {`LINE/L1`, `SINE/Alu`, `Retroposon/SVA`, `Simple_repeat` (SVA-VNTR), `LTR/HERVK`}.
-   - `pangenome.presence-absence.tsv`, `pangenome.presence-absence_trusted.tsv`, `pangenome.presence-absence_human.tsv` — flat TSV presence/absence tables derived from the three VCFs above. See [Trusted subsets and presence-absence TSVs](#trusted-subsets-and-presence-absence-tsvs).
+   - `pangenome.trusted.vcf` — subset of `pangenome.vcf` where `FILTER=PASS` (trusted MEI candidates only). Not produced when `--human` is set.
+   - `pangenome.human.vcf` — only produced when `--human` is set, and produced *instead of* `pangenome.trusted.vcf`. Polymorphic mobile elements only, filtered directly from `pangenome.vcf` on young subfamilies. See [The `--human` pME subset](#the---human-pme-subset).
+   - `human_filter_summary.txt` — only with `--human`. Kept and dropped subfamily tallies for the filter above.
+   - `pangenome.presence-absence.tsv`, `pangenome.presence-absence_trusted.tsv`, `pangenome.presence-absence_human.tsv` — flat TSV presence/absence tables derived one-for-one from the VCFs above. See [Trusted subsets and presence-absence TSVs](#trusted-subsets-and-presence-absence-tsvs).
    - `TSD_summary.txt`: tab-delimited TSD-search report (1 line per variant). See [TSD section](#tsd-module).
    - `TSD_full_log.txt`: verbose TSD-search log.
 - `4_Genotyping/`
@@ -640,7 +649,7 @@ Starting in v1.1, `3_TSD_search/` ships three companion files alongside `pangeno
 
 `pangenome.trusted.vcf` = `bcftools view -f PASS pangenome.vcf` — guaranteed PASS-only.
 
-`pangenome.trusted.human.vcf` (only with `--human`) = trusted subset further restricted to the main human MEI classes: `LINE/L1`, `SINE/Alu`, `Retroposon/SVA`, `Simple_repeat` (SVA-VNTR, see [VNTR polymorphisms in SVA elements](#vntr-polymorphisms-in-sva-elements)), `LTR/HERVK`.
+With `--human`, `pangenome.trusted.vcf` is **not** produced; `pangenome.human.vcf` takes its place and is filtered directly from `pangenome.vcf` — see [The `--human` pME subset](#the---human-pme-subset).
 
 **Presence/absence TSVs** are flat tables derived one-for-one from the three VCFs above (`pangenome.presence-absence.tsv`, `pangenome.presence-absence_trusted.tsv`, `pangenome.presence-absence_human.tsv`). Fixed column schema:
 
@@ -663,6 +672,36 @@ Missing INFO fields are filled with `NA`. No `REF`, `ALT`, `QUAL`, `FILTER`, or 
 > | any          | `./.` or `.`    | `NA`              |
 >
 > Do **not** compare TSV values directly to VCF GT fields — the semantics differ for deletions by design, so the TSV gives you a clean per-sample TE gene-content matrix across both `INS` and `DEL` variants.
+
+#### The `--human` pME subset
+
+The trusted criteria above are deliberately species-agnostic: with no prior expectation about which families are active, they cast a wide net and buy specificity with `n_hits == 1`. In human we know exactly which subfamilies are still mobilizing, so `--human` replaces that heuristic with its own filter, applied **directly to `pangenome.vcf`**. `pangenome.trusted.vcf` is not produced in this mode.
+
+A variant enters `pangenome.human.vcf` when **all** of the following hold:
+
+1. **Young subfamily.** `INFO/repeat_ids` matches one of the whitelists, within the matching class:
+
+   | class | param | default | keeps |
+   |---|---|---|---|
+   | `SINE/Alu` | `--human_alu_ids` | `^AluY` | AluY and all AluY\* subfamilies (AluYa5, AluYb8, AluYg6, …); drops AluS\*/AluJ\* |
+   | `LINE/L1` | `--human_l1_ids` | `^L1HS` | the human-specific L1; drops L1PA2 and older |
+   | `Retroposon/SVA` | `--human_sva_ids` | `^SVA_[DEF]` | SVA_D/E/F; drops SVA_A/B/C |
+   | `Simple_repeat` | `--human_sva_ids` | `^SVA_[DEF]` | SVA-VNTR expansions only (`SVA_F(VNTR_only)` etc., see [VNTR polymorphisms in SVA elements](#vntr-polymorphisms-in-sva-elements)); drops unrelated tandem-repeat expansions |
+   | `LTR/ERVK` | `--human_hervk_ids` | `^HERVK-int,^LTR5_Hs,^LTR5A,^LTR5B` | the strict HML-2 lineage; drops other ERVK families (`HERVK9-int`, `HERVK11-int`, `HERVK22-int`, `HERVKC4-int`, `MER11*`, `LTR13`, …) and the ancestral `LTR5` |
+
+   Each param is a **comma-separated list of regexes**, matched element-wise against `repeat_ids` (bcftools regexes support `^ $ . * [...]` but *not* alternation, hence the lists). Match on prefixes: `repeat_ids` carries `(x)` and `(VNTR_only)` suffixes. Setting a param to the empty string keeps its whole class.
+
+2. **`|SVLEN| >= --human_min_svlen`** (default 250) and **`ULTRA_TR_span < --human_max_ultra_span`** (default 0.6, waived for `Simple_repeat`/SVA-VNTR records).
+
+3. **A single RepeatMasker hit** (`n_hits == 1`) — more than one hit almost always means an SV that carries TE sequence rather than a bona fide transposition product. L1 5' inversions are merged upstream and remain single-hit, so they are unaffected. The one exception is 4.
+
+4. **or the HERV-K proviral pattern**: `n_hits == 2` with classes `{LTR/ERVK, Retroposon/SVA}` and a `HERVK-int` hit, up to `--hervk_pair_max_svlen` (default 10500 bp). `SVA_A` shares homology with `LTR5_Hs`, so RepeatMasker routinely splits a small SVA hit off the LTR of a HML-2 proviral SV; without this exception those records — the full-length and truncated proviral polymorphisms — are all lost to the single-hit rule. Disable with `--hervk_sva_pair false`.
+
+5. **polyA**, for `SINE/Alu`, `LINE/L1` and `Retroposon/SVA` records: `polyA=TRUE` is required as a TPRT signature. HML-2 (no polyA) and SVA-VNTR records are exempt.
+
+6. **`FILTER == "PASS"`**, unless `--human_ignore_filter` is set.
+
+`human_filter_summary.txt` reports the exact expression used, kept counts per class and subfamily, and the tally of dropped pME-class records — so a whitelist that is too strict or too loose for your dataset is visible without re-running anything.
 
 ## TSD module
 
@@ -721,22 +760,24 @@ The classifier runs only on SVs whose `matching_classes` contains `LTR/ERVK` and
 
 For the n_hits==2 case, the SVA bp contribution is **added to λ** when the SVA hit length lies in the empirical "LTR-mimic" window (default 250–400 bp); otherwise the SVA bp is treated as neutral and subtracted from `s` for the coverage-term computation only (so a true HERV-K event accompanied by a separate SVA insertion is not pushed into `H_X`).
 
+> :information_source: These `n_hits == 2` records reach `pangenome.human.vcf` only because the pME filter carves them out explicitly (`--hervk_sva_pair`, on by default) — see [The `--human` pME subset](#the---human-pme-subset). They are still annotated in `pangenome.vcf` either way.
+
 ### Outputs
 
 When `--human` is set, the following are produced in `3_TSD_search/`:
 
-- **VCF annotations** (added to `pangenome.vcf`, `pangenome.trusted.vcf`, `pangenome.trusted.human.vcf`):
+- **VCF annotations** (added to `pangenome.vcf` and `pangenome.human.vcf`):
   - `INFO/HERVK_CLASS=<null_solo|truncated_prov|solo_prov|null_prov|other>` — MAP class.
   - `INFO/HERVK_PMAP=<float>` — posterior probability of the MAP class.
   - `INFO/HERVK_LAMBDA=<float>` — bp matching HML-2 LTR family.
   - `INFO/HERVK_NU=<float>` — bp matching HML-2 INT family.
   - `FORMAT/HERVK_AS=<state[|state]…>` — per-haplotype allelic state derived from each sample's GT and the MAP class (e.g. `solo|null`, `prov|solo`). Set to `?|?` when MAP posterior is below threshold or class is `other`.
-- **TSV annotations** (appended to the three presence-absence TSVs): `HERVK_class`, `HERVK_pmap`, `HERVK_lambda`, `HERVK_nu`. Non-candidate rows get `NA`.
+- **TSV annotations** (appended to `pangenome.presence-absence.tsv` and `pangenome.presence-absence_human.tsv`): `HERVK_class`, `HERVK_pmap`, `HERVK_lambda`, `HERVK_nu`. Non-candidate rows get `NA`.
 - **`hervk_polymorphism_summary.md`** — per-class counts, median \|SVLEN\| per class, posterior confidence distribution, `(x)`-merge breakdown, and a list of polyallelic candidate sites (pairs of `H_C` and `H_B`/`H_T` SVs within 100 bp, suggesting all three alleles segregating at one locus).
 
-### Strict filtering of trusted/human outputs
+### Strict filtering of the human output
 
-The annotation is informational on `pangenome.vcf`. On `pangenome.trusted.vcf` and `pangenome.trusted.human.vcf` (and their TSVs), HERV-K candidate rows whose MAP class is `other` or whose MAP posterior is below the threshold (default `0.90`) are **dropped** to keep these outputs conservative. Non-candidate rows are unaffected.
+The annotation is informational on `pangenome.vcf`. On `pangenome.human.vcf` (and its TSV), HERV-K candidate rows whose MAP class is `other` or whose MAP posterior is below the threshold (default `0.90`) are **dropped** to keep this output conservative. Non-candidate rows are unaffected.
 
 ### Tuning
 

--- a/bin/hervk_classify.py
+++ b/bin/hervk_classify.py
@@ -25,10 +25,10 @@ Usage examples:
         --tsv-out pangenome.presence-absence.hervk.tsv \\
         --summary hervk_polymorphism_summary.md
 
-    # Strict-filter the trusted/human VCF + TSV
+    # Strict-filter the human pME VCF + TSV
     hervk_classify.py --strict \\
-        --vcf-in pangenome.trusted.human.vcf \\
-        --vcf-out pangenome.trusted.human.hervk.vcf \\
+        --vcf-in pangenome.human.vcf \\
+        --vcf-out pangenome.human.hervk.vcf \\
         --tsv-in pangenome.presence-absence_human.tsv \\
         --tsv-out pangenome.presence-absence_human.hervk.tsv
 """

--- a/module/main.nf
+++ b/module/main.nf
@@ -233,11 +233,12 @@ process concat_repeatmask {
 
   output:
   path("pangenome.vcf"), emit: vcf_ch
-  path("pangenome.trusted.vcf")
-  path("pangenome.trusted.human.vcf"), optional: true
+  path("pangenome.trusted.vcf"), optional: true
+  path("pangenome.human.vcf"), optional: true
   path("pangenome.presence-absence.tsv")
-  path("pangenome.presence-absence_trusted.tsv")
+  path("pangenome.presence-absence_trusted.tsv"), optional: true
   path("pangenome.presence-absence_human.tsv"), optional: true
+  path("human_filter_summary.txt"), optional: true
   path("hervk_polymorphism_summary.md"), optional: true
   path("TSD_summary.txt")
   path("TSD_full_log.txt")
@@ -245,7 +246,34 @@ process concat_repeatmask {
   script:
   def trusted_filter = "n_hits==1 & abs(SVLEN)>=${params.trusted_min_svlen} & (ULTRA_TR_span<${params.trusted_max_ultra_span} | matching_classes=\"Simple_repeat\") & ((matching_classes!~\"LINE\" & matching_classes!~\"SINE\" & matching_classes!~\"Retroposon\") | polyA=\"TRUE\")"
   def trusted_filter_full = params.trusted_ignore_filter ? trusted_filter : "(${trusted_filter}) & FILTER=\"PASS\""
-  def human_classes = '(matching_classes="LINE/L1" | matching_classes="SINE/Alu" | matching_classes="Retroposon/SVA" | matching_classes="Simple_repeat" | (matching_classes="LTR/ERVK" & (repeat_ids~"LTR5_Hs" | repeat_ids~"HERVK")))'
+
+  // --human pME filter, applied directly to pangenome.vcf (not to the trusted
+  // subset, which is a species-agnostic heuristic for non-model organisms).
+  // Each whitelist param is a comma-separated list of regexes because bcftools
+  // regexes have no alternation; ~ is matched element-wise on these Number=.
+  // fields, and anchoring with ^ applies per element. Prefixes only: repeat_ids
+  // carry "(x)" and "(VNTR_only)" suffixes from bin/annotate_vcf.R.
+  def orIds = { csv -> '(' + csv.toString().split(',').collect{ "repeat_ids~\"${it.trim()}\"" }.join(' | ') + ')' }
+  def grp   = { cls, csv -> csv?.toString()?.trim() ? "(matching_classes=\"${cls}\" & ${orIds(csv)})" : "matching_classes=\"${cls}\"" }
+  def human_ids = [grp('SINE/Alu',       params.human_alu_ids),
+                   grp('LINE/L1',        params.human_l1_ids),
+                   grp('Retroposon/SVA', params.human_sva_ids),
+                   grp('Simple_repeat',  params.human_sva_ids),
+                   grp('LTR/ERVK',       params.human_hervk_ids)].join(' | ')
+  def human_size   = "abs(SVLEN)>=${params.human_min_svlen} & (ULTRA_TR_span<${params.human_max_ultra_span} | matching_classes=\"Simple_repeat\")"
+  // polyA (TPRT signature) is required for Alu/L1/SVA but not for HML-2 or for
+  // SVA-VNTR expansions. Stated positively: bcftools "!~" does not negate
+  // reliably on these Number=. fields (matching_classes!~"SINE" is true for
+  // every record, including SINE/Alu ones), so the trusted filter's
+  // "!~LINE & !~SINE & !~Retroposon" idiom must not be reused here.
+  def human_single = "n_hits==1 & (matching_classes=\"LTR/ERVK\" | matching_classes=\"Simple_repeat\" | polyA=\"TRUE\")"
+  // HML-2 proviral SVs where RepeatMasker splits a small SVA hit off the LTR
+  // (SVA/LTR5_Hs homology). OR-ed at the n_hits level so it also bypasses the
+  // polyA requirement that "Retroposon" in matching_classes would trigger.
+  def hervk_pair   = "n_hits==2 & matching_classes=\"LTR/ERVK\" & matching_classes=\"Retroposon/SVA\" & repeat_ids~\"^HERVK-int\" & abs(SVLEN)<=${params.hervk_pair_max_svlen}"
+  def human_hits   = params.hervk_sva_pair ? "((${human_single}) | (${hervk_pair}))" : "(${human_single})"
+  def human_filter_base = "(${human_ids}) & ${human_size} & ${human_hits}"
+  def human_filter = params.human_ignore_filter ? human_filter_base : "(${human_filter_base}) & FILTER=\"PASS\""
   """
   cat TSD_summary_*.txt > TSD_summary.txt
   cat TSD_full_log_*.txt > TSD_full_log.txt
@@ -266,24 +294,44 @@ process concat_repeatmask {
   # pangenome.vcf retains the original FILTER values from upstream.
   cp pangenome_raw.vcf pangenome.vcf
 
-  # trusted subset: variants matching the trusted criteria. By default
-  # also requires existing FILTER=="PASS"; bypass with --trusted_ignore_filter.
-  bcftools view -Ov -o pangenome.trusted.vcf -i '${trusted_filter_full}' pangenome.vcf
-
-  # presence-absence TSVs (full + trusted)
+  # presence-absence TSV for the full callset
   vcf_to_pa_tsv.py pangenome.vcf -o pangenome.presence-absence.tsv
-  vcf_to_pa_tsv.py pangenome.trusted.vcf -o pangenome.presence-absence_trusted.tsv
 
-  # human-restricted subset (optional)
-  if [[ "${params.human}" == "true" ]]; then
-    bcftools view -Ov -o pangenome.trusted.human.vcf -i '${human_classes}' pangenome.trusted.vcf
-    vcf_to_pa_tsv.py pangenome.trusted.human.vcf -o pangenome.presence-absence_human.tsv
+  if [[ "${params.human}" != "true" ]]; then
+    # trusted subset: variants matching the trusted criteria. By default
+    # also requires existing FILTER=="PASS"; bypass with --trusted_ignore_filter.
+    bcftools view -Ov -o pangenome.trusted.vcf -i '${trusted_filter_full}' pangenome.vcf
+    vcf_to_pa_tsv.py pangenome.trusted.vcf -o pangenome.presence-absence_trusted.tsv
+  else
+    # --human replaces the trusted subset with a polymorphic-MEI subset built
+    # directly from pangenome.vcf: young subfamilies only (AluY*, L1HS,
+    # SVA_D/E/F, HML-2), single RepeatMasker hit, plus the HERVK-int+SVA
+    # proviral exception.
+    bcftools view -Ov -o pangenome.human.vcf -i '${human_filter}' pangenome.vcf
+    vcf_to_pa_tsv.py pangenome.human.vcf -o pangenome.presence-absence_human.tsv
+
+    {
+      echo "# GraffiTE --human pME filter"
+      echo
+      echo "filter expression:"
+      echo '  ${human_filter}'
+      echo
+      printf 'records in pangenome.vcf       : %s\\n' "\$(bcftools view -H pangenome.vcf | wc -l | tr -d ' ')"
+      printf 'records in pangenome.human.vcf : %s (before HERV-K strict filtering)\\n' "\$(bcftools view -H pangenome.human.vcf | wc -l | tr -d ' ')"
+      echo
+      echo "kept (count, matching_classes, repeat_ids):"
+      bcftools query -f '%INFO/matching_classes\\t%INFO/repeat_ids\\n' pangenome.human.vcf | sort | uniq -c | sort -rn
+      echo
+      echo "dropped pME-class records (count, matching_classes, repeat_ids):"
+      bcftools query -e '${human_filter}' -f '%INFO/matching_classes\\t%INFO/repeat_ids\\n' pangenome.vcf | \\
+        awk -F'\\t' '\$1 ~ /Alu|L1|SVA|Simple_repeat|ERVK/' | sort | uniq -c | sort -rn
+    } > human_filter_summary.txt
 
     # HERV-K (HML-2) classification — runs only on --human pipelines.
     # Annotates the main VCF/TSV without filtering, and applies a strict
-    # filter (drop class==other or pmap<threshold) to the trusted and
-    # human VCF/TSV outputs. Defaults are baked into bin/hervk_classify.py;
-    # users can override via params.hervk_config (path to a JSON file).
+    # filter (drop class==other or pmap<threshold) to the human VCF/TSV.
+    # Defaults are baked into bin/hervk_classify.py; users can override via
+    # params.hervk_config (path to a JSON file).
     CFG_ARG=""
     if [[ -n "${params.hervk_config ?: ''}" ]]; then
       CFG_ARG="--config ${params.hervk_config}"
@@ -298,23 +346,16 @@ process concat_repeatmask {
     mv pangenome.presence-absence.tsv.hervk pangenome.presence-absence.tsv
 
     hervk_classify.py \$CFG_ARG --strict \\
-        --vcf-in pangenome.trusted.vcf --vcf-out pangenome.trusted.vcf.hervk \\
-        --tsv-in pangenome.presence-absence_trusted.tsv \\
-        --tsv-out pangenome.presence-absence_trusted.tsv.hervk
-    mv pangenome.trusted.vcf.hervk pangenome.trusted.vcf
-    mv pangenome.presence-absence_trusted.tsv.hervk pangenome.presence-absence_trusted.tsv
-
-    hervk_classify.py \$CFG_ARG --strict \\
-        --vcf-in pangenome.trusted.human.vcf \\
-        --vcf-out pangenome.trusted.human.vcf.hervk \\
+        --vcf-in pangenome.human.vcf \\
+        --vcf-out pangenome.human.vcf.hervk \\
         --tsv-in pangenome.presence-absence_human.tsv \\
         --tsv-out pangenome.presence-absence_human.tsv.hervk
-    mv pangenome.trusted.human.vcf.hervk pangenome.trusted.human.vcf
+    mv pangenome.human.vcf.hervk pangenome.human.vcf
     mv pangenome.presence-absence_human.tsv.hervk pangenome.presence-absence_human.tsv
   fi
 
   # Stamp GraffiTE version into the header of each published VCF
-  for VCF in pangenome.vcf pangenome.trusted.vcf pangenome.trusted.human.vcf; do
+  for VCF in pangenome.vcf pangenome.trusted.vcf pangenome.human.vcf; do
     [ -f "\$VCF" ] || continue
     awk -v v="${params.graffite_version}" 'NR==1 && /^##fileformat/ {print; print "##GraffiTE_version="v; next} {print}' "\$VCF" > "\$VCF.tmp" && mv "\$VCF.tmp" "\$VCF"
   done

--- a/nextflow.config
+++ b/nextflow.config
@@ -52,8 +52,20 @@ params {
     trusted_min_svlen = 250   // min |SVLEN| for the "trusted" subset (pangenome.trusted.vcf)
     trusted_max_ultra_span = 0.6 // max ULTRA_TR_span for the "trusted" subset
     trusted_ignore_filter = false // if true, do not require existing FILTER=="PASS" for trusted subset
-    human = false             // also emit pangenome.trusted.human.vcf restricted to human MEI classes
+    human = false             // emit pangenome.human.vcf (polymorphic MEI subset) instead of the trusted subset
     hervk_config = null       // path to optional JSON for HERV-K classifier overrides (only used when --human)
+    // --human pME subfamily whitelists: comma-separated lists of bcftools regexes
+    // matched against repeat_ids. bcftools regexes support ^ $ . * [...] but NOT
+    // alternation, hence the lists. An empty string keeps the whole class.
+    human_alu_ids   = "^AluY"                              // AluY* (AluYa5, AluYb8, ...); excludes AluS*/AluJ*
+    human_l1_ids    = "^L1HS"                              // add ^L1PA2 to relax
+    human_sva_ids   = "^SVA_[DEF]"                         // also gates the SVA-VNTR Simple_repeat records
+    human_hervk_ids = "^HERVK-int,^LTR5_Hs,^LTR5A,^LTR5B"  // strict HML-2 lineage
+    human_min_svlen      = 250   // min |SVLEN| for pangenome.human.vcf
+    human_max_ultra_span = 0.6   // max ULTRA_TR_span for pangenome.human.vcf
+    human_ignore_filter  = false // if true, do not require existing FILTER=="PASS" for the human subset
+    hervk_sva_pair       = true  // admit n_hits==2 HERVK-int+SVA proviral records (LTR5_Hs/SVA homology artifact)
+    hervk_pair_max_svlen = 10500 // |SVLEN| cap for the above (9472 bp proviral element + tolerance)
     asm_divergence = "asm5"
     aligner        = "minimap2" // or winnowmap
     min_mapq             = 0

--- a/test/human_filter/CLUSTER_TEST.md
+++ b/test/human_filter/CLUSTER_TEST.md
@@ -209,10 +209,18 @@ The old trusted filter used `matching_classes!~"LINE"`, which does not negate on
 now actually applies:
 
 ```bash
-bcftools view -H -i '(matching_classes="SINE/Alu" | matching_classes="LINE/L1" | matching_classes="Retroposon/SVA") & polyA!="TRUE"' pangenome.human.vcf | wc -l
+bcftools view -H -i 'n_hits==1 & (matching_classes="SINE/Alu" | matching_classes="LINE/L1" | matching_classes="Retroposon/SVA") & polyA!="TRUE"' pangenome.human.vcf | wc -l
 ```
 Expected: `0`. `LTR/ERVK` and `Simple_repeat` records are exempt by design and may have
 `polyA=FALSE` or `NA`.
+
+The `n_hits==1` guard is required, not cosmetic: the HERVK+SVA pair records carry
+`matching_classes=LTR/ERVK,Retroposon/SVA` and `polyA=NA`, so the `Retroposon/SVA`
+element matches and they get false-flagged. Note you cannot fix this by appending
+`& matching_classes!="LTR/ERVK"` — **negation is unreliable on these `Number=.` fields**.
+Both `!=` and `!~` use "some element differs" semantics, so `matching_classes!="LTR/ERVK"`
+is *true* for a record whose classes are `LTR/ERVK,Retroposon/SVA`. Always express
+exclusions positively, or gate on `n_hits`.
 
 **g. Before/after comparison** (only if the previous human VCF was found in §2)
 
@@ -231,14 +239,16 @@ comm -23 /tmp/old.ids /tmp/new.ids > /tmp/dropped.ids
 bcftools query -f '%ID\t%INFO/matching_classes\t%INFO/repeat_ids\n' "$OLD" \
   | grep -Ff /tmp/dropped.ids | cut -f2,3 | sed 's/(x)//' | sort | uniq -c | sort -rn
 ```
-The dropped set must be entirely old subfamilies; the gained set must be entirely
-`n_hits==2` HERVK+SVA records. **If anything else appears in either set, that is a
-finding — report it.**
+The dropped set must be entirely old subfamilies. The gained set is the `n_hits==2`
+HERVK+SVA records **plus any `LTR5A`/`LTR5B` records**: the old class filter tested
+`repeat_ids~"LTR5_Hs" | repeat_ids~"HERVK"`, which matched neither, so those HML-2 solo
+LTRs were never in the old output even though they were in `pangenome.vcf`. **Anything
+else in either set is a finding — report it.**
 
 Anchor numbers, if and only if the `RM_dir` is the 20-sample CaG cohort: old 5855 →
-5747 after the subfamily filter → +12 surviving pairs → **5759**, with drops of 52 Alu,
-32 L1, 3 SVA, 13 SVA-VNTR, 8 non-HML-2 ERVK. For any other dataset, report the observed
-relationship instead of trying to match these.
+5747 after the subfamily filter → +12 surviving HERVK+SVA pairs → +1 newly admitted
+`LTR5A` → **5760**, with drops of 52 Alu, 32 L1, 3 SVA, 13 SVA-VNTR, 8 non-HML-2 ERVK.
+For any other dataset, report the observed relationship instead of trying to match these.
 
 **h. The filter's own report**
 

--- a/test/human_filter/CLUSTER_TEST.md
+++ b/test/human_filter/CLUSTER_TEST.md
@@ -81,8 +81,12 @@ and wait for confirmation before launching.**
 git clone -b v1.1dev-human-filter https://github.com/cgroza/GraffiTE.git
 # reuse the cached image if $NXF_SINGULARITY_CACHEDIR already has it, otherwise:
 singularity pull graffite.sif library://cgroza/collection/graffite:latest
-singularity exec graffite.sif bash GraffiTE/test/human_filter/run_test.sh
+singularity exec --bind "$PWD" graffite.sif bash GraffiTE/test/human_filter/run_test.sh
 ```
+
+(`--bind "$PWD"` because this is a manual `singularity exec` and does not inherit the
+`singularity.runOptions` the pipeline uses. If the clone sits outside an auto-mounted
+path you will otherwise get "No such file or directory" rather than a test failure.)
 
 Expected — 7 `ok` lines and `all human filter tests passed`:
 

--- a/test/human_filter/CLUSTER_TEST.md
+++ b/test/human_filter/CLUSTER_TEST.md
@@ -1,0 +1,274 @@
+# Cluster test: the `--human` pME filter (branch `v1.1dev-human-filter`)
+
+You are running a validation test of a change to GraffiTE's `--human` mode on real data.
+This document assumes no prior context. Read it end to end before running anything.
+
+---
+
+## 1. What changed, and the one thing that can silently break it
+
+`--human` used to take `pangenome.trusted.vcf` (a species-agnostic heuristic subset) and
+filter it by TE **class**. It now builds its output **directly from `pangenome.vcf`** with
+a filter written for human polymorphic mobile elements (pMEs), and keeps only young
+subfamilies:
+
+| class | kept | dropped |
+|---|---|---|
+| `SINE/Alu` | `AluY*` | `AluS*`, `AluJ*` |
+| `LINE/L1` | `L1HS` | `L1PA*`, `L1M*`, `L1P*` |
+| `Retroposon/SVA` | `SVA_D/E/F` | `SVA_A/B/C` |
+| `Simple_repeat` | SVA-VNTR records (`SVA_[DEF](VNTR_only)`) | unrelated tandem repeats |
+| `LTR/ERVK` | strict HML-2: `HERVK-int`, `LTR5_Hs`, `LTR5A`, `LTR5B` | `HERVK9/11/22/C4-int`, `MER11*`, `LTR13`, bare `LTR5` |
+
+Two consequences to expect in the output:
+
+- The file is named **`pangenome.human.vcf`** (was `pangenome.trusted.human.vcf`), and
+  **`pangenome.trusted.vcf` is not produced at all** in `--human` runs.
+- Records with `n_hits==2` annotated `HERVK-int` + SVA are now admitted. These are HML-2
+  proviral SVs where RepeatMasker assigns part of the LTR to SVA (SVA/`LTR5_Hs`
+  homology); the old `n_hits==1` rule discarded every one of them.
+
+**The risk that makes §3 mandatory.** The filter is a single `bcftools view -i`
+expression, and it depends on bcftools-specific regex behavior:
+
+- `~` is evaluated **element-wise** on `Number=.` fields, with `^` anchoring **per
+  element** — `repeat_ids~"^LTR5_Hs"` must match the record `SVA_A,LTR5_Hs`.
+- bcftools regexes have **no alternation** (`|` and `\|` do not work inside a regex), which
+  is why each whitelist is a comma-separated list expanded into OR'd clauses.
+
+This was verified on bcftools 1.22. The GraffiTE container builds bcftools from
+**unpinned git master** (`GraffiTE.def:195`), so the image may carry a different build.
+If its semantics differ, the filter silently keeps the wrong records — it does not error.
+§3 settles this in one command.
+
+---
+
+## 2. Inputs to locate, then confirm with the user
+
+You need three paths. **Do not guess — resolve them, then echo all three back to the user
+and wait for confirmation before launching.**
+
+1. **`RM_dir`** — a previous GraffiTE run's `2_Repeat_Filtering/` directory. This is what
+   lets the run skip SV discovery and RepeatMasker entirely.
+
+   ```bash
+   find <likely-parent-dirs> -maxdepth 4 -type d -name 2_Repeat_Filtering 2>/dev/null
+   ```
+
+   Verify the layout — it must contain numbered subdirectories, each holding both files:
+
+   ```bash
+   ls <RM_dir>                                        # -> 1  2  3  ...
+   ls <RM_dir>/1/genotypes_repmasked_filtered.vcf     # must exist
+   ls -d <RM_dir>/1/repeatmasker_dir                  # must exist
+   ```
+
+   If either is missing the pipeline fails at channel creation with a `checkIfExists`
+   error.
+
+2. **`--reference`** — the **same** reference FASTA used by the original run. `fix_vcf.py`
+   pulls REF alleles from it; a different reference produces wrong REF fields.
+
+3. **Previous human VCF (optional, but do look for it)** — the earlier run's
+   `3_TSD_search/pangenome.trusted.human.vcf`. It is the before-picture for the
+   comparison in §5g. If it does not exist, say so and skip that check.
+
+---
+
+## 3. Pre-flight: verify filter semantics inside the container — BLOCKING
+
+```bash
+git clone -b v1.1dev-human-filter https://github.com/cgroza/GraffiTE.git
+# reuse the cached image if $NXF_SINGULARITY_CACHEDIR already has it, otherwise:
+singularity pull graffite.sif library://cgroza/collection/graffite:latest
+singularity exec graffite.sif bash GraffiTE/test/human_filter/run_test.sh
+```
+
+Expected — 7 `ok` lines and `all human filter tests passed`:
+
+```
+ok   defaults
+ok   human_l1_ids adds L1PA2
+ok   human_min_svlen=100 admits the 140 bp AluY
+ok   hervk_sva_pair=false drops the HERVK+SVA pairs
+ok   human_ignore_filter=true admits the non-PASS record
+ok   human_hervk_ids=^LTR5 admits the ancestral LTR5
+ok   empty human_sva_ids keeps the whole SVA/Simple_repeat classes
+```
+
+**Any `FAIL` here means the container's bcftools does not behave as the filter assumes.
+Stop. Do not launch the pipeline.** Report which case failed, its expected-vs-got line,
+and `singularity exec graffite.sif bcftools --version`. That output is exactly what's
+needed to fix the expression.
+
+Also run it outside the container for comparison if a system bcftools exists — a pass
+outside and a fail inside pinpoints the image.
+
+---
+
+## 4. Launch
+
+```bash
+nextflow pull cgroza/GraffiTE      # REQUIRED: refreshes the cached asset so -r sees the new branch
+
+nextflow run cgroza/GraffiTE -r v1.1dev-human-filter -latest \
+  -profile cluster \
+  --RM_dir    <RM_DIR> \
+  --reference <REFERENCE.fa> \
+  --human \
+  --genotype false \
+  --out       human_filter_test_out \
+  -work-dir   <SCRATCH>/work
+```
+
+- **Use a fresh `--out`.** `publishDir` mode is `copy`, so pointing at the previous run's
+  output directory leaves a stale `pangenome.trusted.human.vcf` sitting next to the new
+  `pangenome.human.vcf` and makes the comparison in §5g ambiguous.
+- **TSD search re-runs** and is the bulk of the runtime — `concat_repeatmask` consumes
+  `tsd_report`'s output, so it cannot be skipped via `--RM_dir`. It is batched at
+  `--tsd_batch_size` variants per task (default 100).
+- **Faster alternative:** if the original run's `work/` directory still exists, add
+  `-resume` and point `-work-dir` at it. Only `concat_repeatmask`'s script changed, so
+  everything upstream — including TSD — comes from cache and the run takes minutes.
+  If `-resume` re-executes TSD anyway, the cache is stale; just let the normal run
+  proceed rather than fighting it.
+
+---
+
+## 5. Post-run checks
+
+Work in `human_filter_test_out/3_TSD_search/`. Each check has a pass criterion — record
+the actual numbers, not just pass/fail.
+
+**a. Expected files exist, trusted files do not**
+
+```bash
+ls -la human_filter_test_out/3_TSD_search/
+```
+Must be present: `pangenome.vcf`, `pangenome.human.vcf`,
+`pangenome.presence-absence.tsv`, `pangenome.presence-absence_human.tsv`,
+`human_filter_summary.txt`, `hervk_polymorphism_summary.md`.
+Must be **absent**: `pangenome.trusted.vcf`, `pangenome.presence-absence_trusted.tsv`,
+`pangenome.trusted.human.vcf`.
+
+**b. Version stamp**
+
+```bash
+grep -m1 GraffiTE_version pangenome.human.vcf
+```
+
+**c. Subfamily purity**
+
+```bash
+bcftools query -f '%INFO/matching_classes\t%INFO/repeat_ids\n' pangenome.human.vcf \
+  | sort | uniq -c | sort -rn
+```
+Every `repeat_ids` value must start with `AluY`, `L1HS`, `SVA_D/E/F`, `HERVK-int`,
+`LTR5_Hs`, `LTR5A` or `LTR5B` (possibly with an `(x)` or `(VNTR_only)` suffix). Assert it
+as an allow-list — a deny-list of known-bad names misses anything unanticipated:
+
+```bash
+bcftools query -i 'n_hits==1' -f '%INFO/repeat_ids\n' pangenome.human.vcf \
+  | sed 's/(.*//' \
+  | grep -Evc '^(AluY|L1HS|SVA_[DEF]|HERVK-int|LTR5_Hs|LTR5A|LTR5B)'
+```
+Expected: `0` (any non-zero count is the number of offending records — drop the `c` from
+`-Evc` to see them). Restricted to `n_hits==1` because the HERVK+SVA pair records
+legitimately carry a second, non-whitelisted `SVA_A` id; those are checked in **d**.
+
+Sanity-check that the assertion actually detects violations by running it against
+`pangenome.vcf` in the same directory — that must return a large non-zero count.
+
+**d. The HERVK+SVA carve-out fired**
+
+```bash
+bcftools view -H -i 'n_hits==2' pangenome.human.vcf | wc -l
+bcftools query -i 'n_hits==2' -f '%INFO/repeat_ids\t%INFO/match_lengths\t%INFO/SVLEN\t%INFO/HERVK_CLASS\t%INFO/HERVK_PMAP\n' pangenome.human.vcf
+```
+Every `n_hits==2` record must be `HERVK-int` + SVA — no other multi-hit records may
+appear. On the CaG cohort, 14 records are admitted by the filter and **12 survive**
+`hervk_classify --strict` (the other 2 classify as `truncated_prov` at pmap ≈0.85, below
+the 0.90 threshold). A different cohort will have different counts; report what you see.
+
+**e. HERV-K annotations**
+
+```bash
+bcftools query -f '%INFO/HERVK_CLASS\t%INFO/HERVK_PMAP\n' pangenome.human.vcf \
+  | grep -v '^\.' | sort | uniq -c
+```
+No `other`, and every `HERVK_PMAP >= 0.90` (that's what `--strict` guarantees).
+
+**f. The polyA rule is now genuinely enforced**
+
+The old trusted filter used `matching_classes!~"LINE"`, which does not negate on these
+`Number=.` fields and so never fired. The human filter states the rule positively, so it
+now actually applies:
+
+```bash
+bcftools view -H -i '(matching_classes="SINE/Alu" | matching_classes="LINE/L1" | matching_classes="Retroposon/SVA") & polyA!="TRUE"' pangenome.human.vcf | wc -l
+```
+Expected: `0`. `LTR/ERVK` and `Simple_repeat` records are exempt by design and may have
+`polyA=FALSE` or `NA`.
+
+**g. Before/after comparison** (only if the previous human VCF was found in §2)
+
+```bash
+OLD=<prev>/3_TSD_search/pangenome.trusted.human.vcf
+NEW=human_filter_test_out/3_TSD_search/pangenome.human.vcf
+bcftools query -f '%ID\n' "$OLD" | sort > /tmp/old.ids
+bcftools query -f '%ID\n' "$NEW" | sort > /tmp/new.ids
+comm -23 /tmp/old.ids /tmp/new.ids | wc -l    # dropped by the new filter
+comm -13 /tmp/old.ids /tmp/new.ids | wc -l    # newly admitted
+```
+Then check *what* was dropped and gained:
+
+```bash
+comm -23 /tmp/old.ids /tmp/new.ids > /tmp/dropped.ids
+bcftools query -f '%ID\t%INFO/matching_classes\t%INFO/repeat_ids\n' "$OLD" \
+  | grep -Ff /tmp/dropped.ids | cut -f2,3 | sed 's/(x)//' | sort | uniq -c | sort -rn
+```
+The dropped set must be entirely old subfamilies; the gained set must be entirely
+`n_hits==2` HERVK+SVA records. **If anything else appears in either set, that is a
+finding — report it.**
+
+Anchor numbers, if and only if the `RM_dir` is the 20-sample CaG cohort: old 5855 →
+5747 after the subfamily filter → +12 surviving pairs → **5759**, with drops of 52 Alu,
+32 L1, 3 SVA, 13 SVA-VNTR, 8 non-HML-2 ERVK. For any other dataset, report the observed
+relationship instead of trying to match these.
+
+**h. The filter's own report**
+
+```bash
+cat human_filter_summary.txt
+```
+It contains the exact bcftools expression used, the kept tally by class and subfamily, and
+the dropped pME-class tally. Include the expression line and both tallies in your report.
+
+---
+
+## 6. Triage
+
+| symptom | likely cause |
+|---|---|
+| `pangenome.trusted.vcf` still produced | Running old cached code. `nextflow pull cgroza/GraffiTE`, confirm `-r v1.1dev-human-filter -latest`. |
+| 0 or absurdly few records kept | Container bcftools regex semantics — §3 should have caught this. Re-run §3 and report. |
+| `no such tag defined in the VCF header` for `ULTRA_TR_span` / `polyA` | The `RM_dir` predates those INFO fields. Needs a newer RepeatMasker stage; not a filter bug. Report the `RM_dir` provenance. |
+| `checkIfExists` error on `genotypes_repmasked_filtered.vcf` | `--RM_dir` points at the wrong level. It must be the `2_Repeat_Filtering` directory itself, not a numbered subdir and not the run root. |
+| `n_hits==2` count is 0 | Check the cohort actually has such records before calling it a regression: `bcftools view -H -i 'n_hits==2 & matching_classes="LTR/ERVK" & matching_classes="Retroposon/SVA" & repeat_ids~"^HERVK-int"' pangenome.vcf \| wc -l` |
+| TSD search takes far longer than expected | Expected — it re-runs in full. Use `-resume` against the original `work/` if it exists. |
+
+---
+
+## 7. Report back
+
+Send the user:
+
+1. Pass/fail for §3, with the container's `bcftools --version`.
+2. The full `human_filter_summary.txt`.
+3. Counts from §5c (purity assertion), §5d (pair count, admitted vs surviving), §5g
+   (dropped / gained, with the breakdown).
+4. Anything that failed, with the command and its output.
+
+Do **not** merge this branch — it is a test branch. Do not "fix" unexpected results by
+editing the filter expression in place; report them so the change can be corrected at the
+source.

--- a/test/human_filter/human_filter_fixture.vcf
+++ b/test/human_filter/human_filter_fixture.vcf
@@ -1,0 +1,31 @@
+##fileformat=VCFv4.2
+##contig=<ID=chr1,length=100000>
+##INFO=<ID=SVLEN,Number=1,Type=Integer,Description="Length of the SV">
+##INFO=<ID=n_hits,Number=1,Type=Integer,Description="Number of repeats found in insertion">
+##INFO=<ID=match_lengths,Number=.,Type=Integer,Description="Insertion lengths spanned by each repeat">
+##INFO=<ID=repeat_ids,Number=.,Type=String,Description="Repeat family IDs">
+##INFO=<ID=matching_classes,Number=.,Type=String,Description="Repeat class names">
+##INFO=<ID=ULTRA_TR_span,Number=1,Type=Float,Description="Fraction of the variant covered by tandem repeats">
+##INFO=<ID=polyA,Number=1,Type=String,Description="polyA tail detected">
+##FILTER=<ID=PASS,Description="All filters passed">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+chr1	1000	AluY	A	<INS>	.	PASS	SVLEN=312;n_hits=1;match_lengths=310;repeat_ids=AluYa5(x);matching_classes=SINE/Alu;ULTRA_TR_span=0.05;polyA=TRUE
+chr1	2000	AluSx	A	<INS>	.	PASS	SVLEN=298;n_hits=1;match_lengths=295;repeat_ids=AluSx;matching_classes=SINE/Alu;ULTRA_TR_span=0.05;polyA=TRUE
+chr1	3000	L1HS	A	<INS>	.	PASS	SVLEN=6019;n_hits=1;match_lengths=6015;repeat_ids=L1HS;matching_classes=LINE/L1;ULTRA_TR_span=0.02;polyA=TRUE
+chr1	4000	L1PA2	A	<INS>	.	PASS	SVLEN=6035;n_hits=1;match_lengths=6025;repeat_ids=L1PA2;matching_classes=LINE/L1;ULTRA_TR_span=0.02;polyA=TRUE
+chr1	5000	SVAD	A	<INS>	.	PASS	SVLEN=855;n_hits=1;match_lengths=850;repeat_ids=SVA_D(VNTR_only);matching_classes=Simple_repeat;ULTRA_TR_span=0.95;polyA=TRUE
+chr1	6000	SVAF	A	<INS>	.	PASS	SVLEN=1400;n_hits=1;match_lengths=1390;repeat_ids=SVA_F;matching_classes=Retroposon/SVA;ULTRA_TR_span=0.30;polyA=TRUE
+chr1	7000	SVAA	A	<INS>	.	PASS	SVLEN=1300;n_hits=1;match_lengths=1290;repeat_ids=SVA_A;matching_classes=Retroposon/SVA;ULTRA_TR_span=0.30;polyA=TRUE
+chr1	8000	LTR5Hs	A	<INS>	.	PASS	SVLEN=968;n_hits=1;match_lengths=966;repeat_ids=LTR5_Hs;matching_classes=LTR/ERVK;ULTRA_TR_span=0.01;polyA=FALSE
+chr1	9000	HERVKint	A	<INS>	.	PASS	SVLEN=8504;n_hits=1;match_lengths=8502;repeat_ids=HERVK-int(x);matching_classes=LTR/ERVK;ULTRA_TR_span=0.01;polyA=FALSE
+chr1	10000	HERVK9	A	<INS>	.	PASS	SVLEN=5668;n_hits=1;match_lengths=5660;repeat_ids=HERVK9-int;matching_classes=LTR/ERVK;ULTRA_TR_span=0.01;polyA=FALSE
+chr1	11000	PAIRfwd	A	<INS>	.	PASS	SVLEN=8229;n_hits=2;match_lengths=8199,327;repeat_ids=HERVK-int(x),SVA_A;matching_classes=LTR/ERVK,Retroposon/SVA;ULTRA_TR_span=0.02;polyA=FALSE
+chr1	12000	PAIRrev	A	<INS>	.	PASS	SVLEN=8504;n_hits=2;match_lengths=172,8328;repeat_ids=SVA_A,HERVK-int(x);matching_classes=Retroposon/SVA,LTR/ERVK;ULTRA_TR_span=0.02;polyA=FALSE
+chr1	13000	PAIRbig	A	<INS>	.	PASS	SVLEN=20000;n_hits=2;match_lengths=19700,300;repeat_ids=HERVK-int(x),SVA_A;matching_classes=LTR/ERVK,Retroposon/SVA;ULTRA_TR_span=0.02;polyA=FALSE
+chr1	14000	PAIRother	A	<INS>	.	PASS	SVLEN=3000;n_hits=2;match_lengths=290,2700;repeat_ids=AluSx,L1PA7;matching_classes=SINE/Alu,LINE/L1;ULTRA_TR_span=0.02;polyA=TRUE
+chr1	15000	AluYshort	A	<INS>	.	PASS	SVLEN=140;n_hits=1;match_lengths=138;repeat_ids=AluY;matching_classes=SINE/Alu;ULTRA_TR_span=0.05;polyA=TRUE
+chr1	16000	AluYnopolyA	A	<INS>	.	PASS	SVLEN=310;n_hits=1;match_lengths=305;repeat_ids=AluY;matching_classes=SINE/Alu;ULTRA_TR_span=0.05;polyA=FALSE
+chr1	17000	AluYnopass	A	<INS>	.	.	SVLEN=310;n_hits=1;match_lengths=305;repeat_ids=AluY;matching_classes=SINE/Alu;ULTRA_TR_span=0.05;polyA=TRUE
+chr1	18000	AluYtr	A	<INS>	.	PASS	SVLEN=320;n_hits=1;match_lengths=315;repeat_ids=AluY;matching_classes=SINE/Alu;ULTRA_TR_span=0.80;polyA=TRUE
+chr1	19000	L1HSdel	A	<DEL>	.	PASS	SVLEN=-6019;n_hits=1;match_lengths=6015;repeat_ids=L1HS;matching_classes=LINE/L1;ULTRA_TR_span=0.02;polyA=TRUE
+chr1	20000	LTR5	A	<INS>	.	PASS	SVLEN=970;n_hits=1;match_lengths=965;repeat_ids=LTR5;matching_classes=LTR/ERVK;ULTRA_TR_span=0.01;polyA=FALSE

--- a/test/human_filter/run_test.sh
+++ b/test/human_filter/run_test.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Regression test for the --human pME filter (module/main.nf, process
+# concat_repeatmask). Builds the same bcftools expression from the defaults in
+# nextflow.config and checks which fixture records survive.
+#
+# The expression assembly below mirrors the Groovy in module/main.nf and must be
+# kept in sync with it.
+#
+# Usage: bash test/human_filter/run_test.sh
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VCF="${HERE}/human_filter_fixture.vcf"
+CONFIG="${HERE}/../../nextflow.config"
+
+command -v bcftools >/dev/null || { echo "bcftools not found"; exit 1; }
+
+# --- defaults from nextflow.config -------------------------------------------
+cfg() { sed -n "s/^[[:space:]]*$1[[:space:]]*=[[:space:]]*\"\{0,1\}\([^\"\/]*\)\"\{0,1\}.*/\1/p" "$CONFIG" | head -1 | sed 's/[[:space:]]*$//'; }
+ALU=$(cfg human_alu_ids);        L1=$(cfg human_l1_ids)
+SVA=$(cfg human_sva_ids);        HERVK=$(cfg human_hervk_ids)
+MINSV=$(cfg human_min_svlen);    MAXTR=$(cfg human_max_ultra_span)
+IGNORE=$(cfg human_ignore_filter); PAIR=$(cfg hervk_sva_pair)
+PAIRMAX=$(cfg hervk_pair_max_svlen)
+
+# --- expression assembly (mirrors module/main.nf) ----------------------------
+or_ids() { # comma-separated regex list -> OR'd repeat_ids clauses
+  local out="" re
+  IFS=',' read -ra RE <<< "$1"
+  for re in "${RE[@]}"; do
+    re="$(echo "$re" | tr -d '[:space:]')"
+    [ -n "$out" ] && out+=" | "
+    out+="repeat_ids~\"${re}\""
+  done
+  echo "(${out})"
+}
+grp() { # class, regex list
+  if [ -n "$2" ]; then echo "(matching_classes=\"$1\" & $(or_ids "$2"))"
+  else echo "matching_classes=\"$1\""; fi
+}
+
+build_filter() {
+  local ids size single pair hits base
+  ids="$(grp 'SINE/Alu' "$ALU") | $(grp 'LINE/L1' "$L1") | $(grp 'Retroposon/SVA' "$SVA") | $(grp 'Simple_repeat' "$SVA") | $(grp 'LTR/ERVK' "$HERVK")"
+  size="abs(SVLEN)>=${MINSV} & (ULTRA_TR_span<${MAXTR} | matching_classes=\"Simple_repeat\")"
+  single="n_hits==1 & (matching_classes=\"LTR/ERVK\" | matching_classes=\"Simple_repeat\" | polyA=\"TRUE\")"
+  pair="n_hits==2 & matching_classes=\"LTR/ERVK\" & matching_classes=\"Retroposon/SVA\" & repeat_ids~\"^HERVK-int\" & abs(SVLEN)<=${PAIRMAX}"
+  if [ "$PAIR" = "true" ]; then hits="((${single}) | (${pair}))"; else hits="(${single})"; fi
+  base="(${ids}) & ${size} & ${hits}"
+  if [ "$IGNORE" = "true" ]; then echo "$base"; else echo "(${base}) & FILTER=\"PASS\""; fi
+}
+
+kept() { bcftools query -i "$(build_filter)" -f '%ID\n' "$VCF" 2>/dev/null | grep -v '^pass=' | sort | tr '\n' ' ' | sed 's/ $//'; }
+
+fail=0
+check() { # name, expected
+  local got; got="$(kept)"
+  if [ "$got" = "$2" ]; then
+    printf 'ok   %s\n' "$1"
+  else
+    printf 'FAIL %s\n       expected: %s\n       got     : %s\n' "$1" "$2" "$got"; fail=1
+  fi
+}
+
+# --- cases -------------------------------------------------------------------
+check "defaults" \
+  "AluY HERVKint L1HS L1HSdel LTR5Hs PAIRfwd PAIRrev SVAD SVAF"
+
+L1="^L1HS,^L1PA2"
+check "human_l1_ids adds L1PA2" \
+  "AluY HERVKint L1HS L1HSdel L1PA2 LTR5Hs PAIRfwd PAIRrev SVAD SVAF"
+L1="$(cfg human_l1_ids)"
+
+MINSV=100
+check "human_min_svlen=100 admits the 140 bp AluY" \
+  "AluY AluYshort HERVKint L1HS L1HSdel LTR5Hs PAIRfwd PAIRrev SVAD SVAF"
+MINSV=$(cfg human_min_svlen)
+
+PAIR=false
+check "hervk_sva_pair=false drops the HERVK+SVA pairs" \
+  "AluY HERVKint L1HS L1HSdel LTR5Hs SVAD SVAF"
+PAIR=$(cfg hervk_sva_pair)
+
+IGNORE=true
+check "human_ignore_filter=true admits the non-PASS record" \
+  "AluY AluYnopass HERVKint L1HS L1HSdel LTR5Hs PAIRfwd PAIRrev SVAD SVAF"
+IGNORE=$(cfg human_ignore_filter)
+
+HERVK="^HERVK-int,^LTR5"
+check "human_hervk_ids=^LTR5 admits the ancestral LTR5" \
+  "AluY HERVKint L1HS L1HSdel LTR5 LTR5Hs PAIRfwd PAIRrev SVAD SVAF"
+HERVK=$(cfg human_hervk_ids)
+
+SVA=""
+check "empty human_sva_ids keeps the whole SVA/Simple_repeat classes" \
+  "AluY HERVKint L1HS L1HSdel LTR5Hs PAIRfwd PAIRrev SVAA SVAD SVAF"
+SVA=$(cfg human_sva_ids)
+
+echo
+if [ "$fail" -eq 0 ]; then echo "all human filter tests passed"; else echo "human filter tests FAILED"; fi
+exit "$fail"


### PR DESCRIPTION
## Summary

`--human` filtered `pangenome.trusted.vcf` by TE **class**, which is too coarse for a polymorphic mobile element (pME) callset: fixed old subfamilies (AluSx, L1PA4, SVA_A) rode along with the young ones, and the unanchored `repeat_ids~"HERVK"` admitted entire non-HML-2 lineages. `trusted` was also the wrong parent — it is a species-agnostic heuristic for non-model organisms, and inheriting its `n_hits==1` rule made the HERVK+SVA carve-out in `bin/hervk_classify.py:260` unreachable.

This PR gives `--human` its own filter, applied directly to `pangenome.vcf`.

**Kept, by class:**

| class | kept | dropped |
|---|---|---|
| `SINE/Alu` | `AluY*` | `AluS*`, `AluJ*` |
| `LINE/L1` | `L1HS` | `L1PA*`, `L1M*`, `L1P*` |
| `Retroposon/SVA` | `SVA_D/E/F` | `SVA_A/B/C` |
| `Simple_repeat` | SVA-VNTR records only | unrelated tandem repeats |
| `LTR/ERVK` | strict HML-2: `HERVK-int`, `LTR5_Hs`, `LTR5A`, `LTR5B` | `HERVK9/11/22/C4-int`, `MER11*`, `LTR13`, ancestral `LTR5` |

Plus the `n_hits==2` `HERVK-int`+SVA proviral pattern — HML-2 proviral SVs where RepeatMasker assigns part of the LTR to SVA (SVA/`LTR5_Hs` homology). The single-hit rule discarded every one of them.

Whitelists and thresholds are params (`human_alu_ids`, `human_l1_ids`, `human_sva_ids`, `human_hervk_ids`, `human_min_svlen`, `human_max_ultra_span`, `human_ignore_filter`, `hervk_sva_pair`, `hervk_pair_max_svlen`), so tuning a subfamily set needs no code change. `human_filter_summary.txt` is published beside the VCF with the exact expression used and kept/dropped tallies per subfamily.

## Breaking changes

- `pangenome.trusted.human.vcf` → **`pangenome.human.vcf`** (it is no longer a subset of trusted).
- `pangenome.trusted.vcf` and `pangenome.presence-absence_trusted.tsv` are **not produced** in `--human` runs.

Non-`--human` runs are byte-identical: `trusted_filter` is untouched.

## A bcftools gotcha, documented in-code

`bcftools` **negation is unreliable on `Number=.` fields** — both `!~` and `!=` use "some element differs" semantics. `matching_classes!~"SINE"` is true for *every* record, including `SINE/Alu` ones (verified on real data: 5855/5855). The polyA rule is therefore stated positively here. This means the same idiom in `trusted_filter` (`module/main.nf:247`) is a silent no-op — criterion 4 in the README has never actually been enforced. **Not fixed in this PR** to keep non-human output unchanged; it happens to cost nothing on CaG data (all Alu/L1/SVA records have `polyA=TRUE` anyway), but it deserves its own change.

## Validation

`test/human_filter/run_test.sh` — 12-record fixture, 7 cases covering the defaults and each param override. Runs anywhere with bash + bcftools.

Full pipeline run on the 20-sample CaG cohort (Puma HPC, `--RM_dir` + `--genotype false`, 962 processes, 8h17m), container bcftools `1.16-81-g8f54545`:

- Pre-flight 7/7 inside the container — confirms the regex semantics hold on that build.
- Subfamily purity: **0** violations; negative control against unfiltered `pangenome.vcf` returned 73614, confirming the assertion discriminates.
- Carve-out: **14** pairs admitted, **12** surviving `hervk_classify --strict`, pmap 0.9936–1.
- Before/after: 5855 → **5760**. Dropped 108, exactly as predicted: 52 Alu, 32 L1, 3 SVA, 13 SVA-VNTR, 8 non-HML-2 ERVK.
- No `HERVK_CLASS=other`, all `HERVK_PMAP ≥ 0.90`.

Two items the run surfaced, both in the check script rather than the filter, both fixed in `f34e921`:

1. The §5f polyA check false-flagged the 12 pair records (`matching_classes=LTR/ERVK,Retroposon/SVA`, `polyA=NA` — the `Retroposon/SVA` element matches). Gated on `n_hits==1`. Note the suggested fix of appending `matching_classes!="LTR/ERVK"` does *not* work, for the negation reason above — verified.
2. The predicted count was 5759 and the run gave 5760. The extra record is an `LTR5A` solo LTR. The old class filter tested `repeat_ids~"LTR5_Hs" | repeat_ids~"HERVK"`, matching neither, so `LTR5A`/`LTR5B` records were never in the old output despite being in `pangenome.vcf` — this is the intended effect of using the full HML-2 lineage, not an anomaly.

## Follow-ups (not in this PR)

- `trusted_filter`'s `!~` no-op described above.
- `hervk_polymorphism_summary.md` is generated from the `pangenome.vcf` pass (`module/main.nf:296`), so its counts describe a superset of what lands in the human output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)