### PR TITLE
fix(hervk): land the two post-review fixes that #94 missed

### DIFF
--- a/bin/hervk_arch.py
+++ b/bin/hervk_arch.py
@@ -204,7 +204,10 @@ def reassign_sine_r(frags, cfg):
     for f in frags:
         if not is_sva_family(f['name']):
             continue
-        if f['cons_start'] < cfg['sine_r_min']:
+        # A hit from a BED annotation has no consensus coordinates, so there
+        # is no way to tell the SINE-R domain from the rest of SVA. Leave it
+        # alone rather than guess -- and never compare None to an int.
+        if f['cons_start'] is None or f['cons_start'] < cfg['sine_r_min']:
             continue
         gap = min(max(f['qstart'] - o['qend'], o['qstart'] - f['qend'], 0)
                   for o in hml2)

--- a/bin/hervk_reconcile.py
+++ b/bin/hervk_reconcile.py
@@ -53,6 +53,7 @@ Usage:
 
 import argparse
 import gzip
+import re
 import sys
 from collections import defaultdict
 
@@ -345,6 +346,34 @@ def detect_genotyper(vcf_path):
     if 'KC' in fmt_ids:          # PanGenie's kmer count, if it named nothing
         return 'pangenie'
     return None
+
+
+ID_RE = re.compile(r'##(?:INFO|FORMAT)=<ID=([^,>]+)')
+
+
+def merge_headers(head, new_lines):
+    """Drop any INFO/FORMAT definition from `head` that `new_lines` redefines.
+
+    Two ##INFO lines with the same ID is invalid VCF and readers disagree about
+    which one wins, so ours must replace rather than append. Number=A is the
+    correct shape for both kinds of record here: a consolidated locus carries
+    one SVTYPE/SVLEN per ALT, and a record carried over unchanged is biallelic,
+    so one ALT means one value. Filtering by ID also makes a second
+    consolidation pass over our own output idempotent.
+    """
+    ids = set()
+    for h in new_lines:
+        m = ID_RE.match(h)
+        if m:
+            ids.add(m.group(1))
+    keep = []
+    for h in head:
+        m = ID_RE.match(h)
+        if m and m.group(1) in ids:
+            continue
+        keep.append(h)
+    return keep
+
 
 CONSOLIDATED_HEADERS = [
     '##INFO=<ID=SVTYPE,Number=A,Type=String,Description="Variant type per ALT.">',
@@ -766,7 +795,7 @@ def write_consolidated(args, head, samples, consolidated, dropped, archived,
         out_by_id[c['mem'][0]] = fields
 
     with open(args.out_vcf, 'w') as fh:
-        for h in head:
+        for h in merge_headers(head, CONSOLIDATED_HEADERS):
             fh.write(h + '\n')
         for h in CONSOLIDATED_HEADERS:
             fh.write(h + '\n')

--- a/test/hervk/test_arch.sh
+++ b/test/hervk/test_arch.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Regression test for hervk_arch.py's SINE-R reassignment.
+#
+# reassign_sine_r() decides whether an SVA hit beside an HML-2 element is really
+# the LTR-derived SINE-R domain, and it decides that from the SVA consensus
+# START coordinate. Hits that come from a BED4 annotation -- the
+# --hervk_ref_annotation path in hervk_ref_state.py -- have no consensus
+# coordinates at all, so that field is None and the comparison used to raise
+# TypeError. The fix must skip those hits WITHOUT disabling the reassignment for
+# real RepeatMasker hits, which is what the second case here pins down.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+fail=0
+chk(){ if [[ "$2" == "$3" ]]; then echo "  [ ok ] $1"; else
+       echo "  [FAIL] $1: got '$2', want '$3'"; fail=1; fi; }
+
+out=$(python3 - <<'EOF'
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location('hervk_arch', '../../bin/hervk_arch.py')
+m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
+
+def frag(name, klass, cs, ce, qs, qe, sw):
+    return {'name': name, 'klass': klass, 'cons_start': cs, 'cons_end': ce,
+            'cons_len': (ce or 0), 'qstart': qs, 'qend': qe, 'bp': qe - qs + 1,
+            'sw': sw, 'strand': '+', 'link': name}
+
+INT = lambda: frag('HERVK-int', 'LTR/ERVK', 1, 7536, 310, 7845, 5000)
+
+# All three cases share one geometry -- the SVA hit abuts the internal region
+# with a 9 bp gap, well inside sine_r_max_gap -- so consensus START is the only
+# variable between them.
+# 1. BED4-derived: no consensus coordinates anywhere.
+try:
+    r = m.reassign_sine_r([frag('SVA_A', 'Retroposon/SVA', None, None, 1, 300, 1000),
+                           INT()], m.DEFAULTS)
+    print('bed_ok', 'yes')
+    print('bed_reassigned', 'yes' if not any(f['name'].startswith('SVA') for f in r) else 'no')
+except TypeError:
+    print('bed_ok', 'no'); print('bed_reassigned', 'crash')
+
+# 2. A real RepeatMasker hit in the SINE-R range still gets reassigned --
+#    the None guard must not silently switch the whole mechanism off.
+r = m.reassign_sine_r([frag('SVA_A', 'Retroposon/SVA', 951, 1113, 1, 300, 1000),
+                       INT()], m.DEFAULTS)
+print('rm_reassigned', 'yes' if not any(f['name'].startswith('SVA') for f in r) else 'no')
+
+# 3. A real hit BELOW the SINE-R threshold is left alone.
+r = m.reassign_sine_r([frag('SVA_A', 'Retroposon/SVA', 100, 400, 1, 300, 1000),
+                       INT()], m.DEFAULTS)
+print('rm_low_reassigned', 'yes' if not any(f['name'].startswith('SVA') for f in r) else 'no')
+EOF
+)
+g(){ echo "$out" | awk -v k="$1" '$1==k{print $2}'; }
+
+chk "BED4 hit without consensus coords does not crash" "$(g bed_ok)"            "yes"
+chk "BED4 hit is left as SVA (cannot identify SINE-R)" "$(g bed_reassigned)"    "no"
+chk "real SINE-R hit is still reassigned to LTR"       "$(g rm_reassigned)"     "yes"
+chk "hit below the SINE-R threshold is left alone"     "$(g rm_low_reassigned)" "no"
+
+[[ $fail -eq 0 ]] && echo "PASS" || { echo "FAIL"; exit 1; }

--- a/test/hervk/test_consolidate.sh
+++ b/test/hervk/test_consolidate.sh
@@ -63,4 +63,18 @@ chk "chr6 tandem has no called GT" \
 chk "chr6 partner keeps its genotypes" \
     "$(awk -F'\t' '$3=="chr6-78894317-DEL-8465_106220"' "$TMP/out.vcf" | cut -f10- | tr '\t' '\n' | cut -d: -f1 | grep -c '1' | tr -d ' ')" "8"
 
+# Header validity. The input fixture defines SVTYPE (Number=1) and SVLEN
+# (Number=.), and the consolidated records carry one value per ALT, so our
+# Number=A definitions have to REPLACE those rather than sit beside them --
+# two ##INFO lines with one ID is invalid VCF and readers disagree on the winner.
+chk "no INFO id defined twice" \
+    "$(grep '^##INFO=<ID=' "$TMP/out.vcf" | sed 's/##INFO=<ID=\([^,>]*\).*/\1/' | sort | uniq -d | wc -l | tr -d ' ')" "0"
+chk "SVTYPE defined once"  "$(grep -c '##INFO=<ID=SVTYPE,' "$TMP/out.vcf")" "1"
+chk "SVLEN defined once"   "$(grep -c '##INFO=<ID=SVLEN,'  "$TMP/out.vcf")" "1"
+chk "SVTYPE is per-ALT"    "$(grep -c '##INFO=<ID=SVTYPE,Number=A,' "$TMP/out.vcf")" "1"
+chk "SVLEN is per-ALT"     "$(grep -c '##INFO=<ID=SVLEN,Number=A,'  "$TMP/out.vcf")" "1"
+# the multiallelic locus is what makes Number=A load-bearing
+chk "multiallelic SVLEN kept per-ALT" \
+    "$(awk -F'\t' '$3=="HERVK_chr12_55299985"' "$TMP/out.vcf" | grep -o 'SVLEN=[^;]*' | head -1)" "SVLEN=-974,8212"
+
 [[ $fail -eq 0 ]] && echo "PASS" || { echo "FAIL"; exit 1; }


### PR DESCRIPTION
PR #94 merged `v1.1dev-hervk-v2` into `v1.1dev` on 2026-08-28 (`a8d7cc2`). Two
commits answering the Copilot review on that PR landed on `v1.1dev-hervk-v2`
about six hours later. No follow-up PR carried them across, so `v1.1dev` still
has both bugs. This cherry-picks them.

The tree here is byte-identical to `v1.1dev-hervk-v2` for `bin/` and
`test/hervk/`.

## What was broken

**`1415680`: SINE-R reassignment crashes on BED4 input.** `reassign_sine_r()`
decides whether an SVA hit beside an HML-2 element is the LTR-derived SINE-R
domain, and it reads the SVA consensus start coordinate to do so. Hits parsed
from a BED4 annotation carry `None` for all three consensus fields, so that
comparison raised `TypeError`. This is the `--hervk_ref_annotation` path in
`hervk_ref_state.py`, which is the only way to skip re-masking the reference.
The guard skips such hits: with no consensus coordinates there is no way to
tell SINE-R from the rest of SVA, so declining to reassign is the conservative
answer.

**`a487582`: consolidated VCFs define `SVTYPE` and `SVLEN` twice.**
`write_consolidated()` wrote the input header and then appended
`CONSOLIDATED_HEADERS` unconditionally. Both GraffiTE VCFs and vg output
already define those two keys, so every consolidated file carried two
definitions of each with conflicting `Number=`. That is invalid VCF, and vcfR
warns on every read. `merge_headers()` now drops any input definition that
`CONSOLIDATED_HEADERS` redefines. Filtering by ID also makes a second
consolidation pass over our own output idempotent.

## Verification

Both bugs reproduce on `v1.1dev` as it stands. We checked out `origin/v1.1dev`
in a detached worktree, copied in the two new test files, and ran them:

```
[FAIL] BED4 hit without consensus coords does not crash: got 'no', want 'yes'
[FAIL] BED4 hit is left as SVA (cannot identify SINE-R): got 'crash', want 'no'
[FAIL] no INFO id defined twice: got '2', want '0'
[FAIL] SVTYPE defined once: got '2', want '1'
[FAIL] SVLEN defined once: got '2', want '1'
```

On this branch both suites pass: `test_arch.sh` 4 of 4, `test_consolidate.sh`
22 of 22.

## Downstream

We patched `hervk_reconciled_v2.vcf.gz` in the paper working set by hand for
the duplicate headers. Regenerating it from `v1.1dev` brings them back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fj8VQeNbgQjJCgXi4nhAmm
