### PR TITLE
fix(pangenie): duplicate IDs in the graph input, and only one sample genotyped (#93)

### DIFF
--- a/bin/pangenie_graph_vcf.py
+++ b/bin/pangenie_graph_vcf.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Build the PanGenie graph input from pangenome.vcf and track each variant.
+
+prepare: write the one-sample VCF that merge_vcfs.py turns into the graph, and
+         a table with one row per ALT allele of pangenome.vcf.
+report:  fill the table's in_graph column from merge_vcfs.py output.
+
+merge_vcfs.py raises an error unless each record has one ID per ALT allele
+after `bcftools norm -m+` joins the records at a position (#93). norm breaks
+that count for two records with the same CHROM/POS/REF/ALT and different IDs
+(it keeps one ALT and both IDs), for two records with one ID and different
+ALTs (it keeps the ID once), and for a record with ID "." beside another at
+its position (it drops the "."). prepare makes one graph variant of records
+with the same CHROM/POS/REF/ALT, and replaces an ID that is missing, already
+used, or contains a character merge_vcfs.py or PanGenie splits on.
+
+PanGenie writes the graph ID of each allele to INFO/ID of the genotyped VCFs.
+To find the genotype of a pangenome.vcf record, look up its graph_ID in the
+table and match it against INFO/ID.
+"""
+
+import argparse
+import sys
+
+RESERVED = set(';,:=| \t')
+COLUMNS = ['record', 'CHROM', 'POS', 'pangenome_ID', 'allele', 'graph_ID', 'in_graph', 'note']
+
+
+def safe_id(vid):
+    return vid != '.' and vid != '' and not (set(vid) & RESERVED)
+
+
+def prepare(vcf_in, vcf_out, table_out):
+    used = set()
+    graph_id_of = {}    # (CHROM, POS, REF, ALT) -> (graph ID, record number)
+    rows = []
+    n_dup = n_renamed = 0
+    record = 0
+
+    with open(vcf_in) as fin, open(vcf_out, 'w') as fout:
+        has_gt = False
+        for line in fin:
+            if line.startswith('##'):
+                if line.startswith('##FORMAT=<ID=GT,'):
+                    has_gt = True
+                fout.write(line)
+                continue
+            if line.startswith('#'):
+                if not has_gt:
+                    fout.write('##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n')
+                fout.write('\t'.join(line.rstrip('\n').split('\t')[:8] + ['FORMAT', 'ref']) + '\n')
+                continue
+
+            record += 1
+            f = line.rstrip('\n').split('\t')
+            chrom, pos, vid, ref, alts = f[0], f[1], f[2], f[3], f[4].split(',')
+            # There is no reliable way to pair several IDs (a;b) with ALT
+            # alleles, so safe_id() rejects them and the alleles get new IDs.
+            for i, alt in enumerate(alts, start=1):
+                key = (chrom, pos, ref, alt)
+                row = {'record': record, 'CHROM': chrom, 'POS': pos, 'pangenome_ID': vid,
+                       'allele': i, 'in_graph': 'no', 'note': '.'}
+                if key in graph_id_of:
+                    gid, first = graph_id_of[key]
+                    row['graph_ID'] = gid
+                    row['note'] = 'duplicate_of_record_%d' % first
+                    n_dup += 1
+                    rows.append(row)
+                    continue
+
+                if len(alts) == 1 and safe_id(vid) and vid not in used:
+                    gid = vid
+                else:
+                    gid = 'graffite_rec%d' % record + ('_%d' % i if len(alts) > 1 else '')
+                    while gid in used:
+                        gid += '_x'
+                    row['note'] = 'id_replaced'
+                    n_renamed += 1
+                used.add(gid)
+                graph_id_of[key] = (gid, record)
+                row['graph_ID'] = gid
+                rows.append(row)
+                fout.write('\t'.join([chrom, pos, gid, ref, alt, f[5], f[6], '.', 'GT', '1|0']) + '\n')
+
+    with open(table_out, 'w') as t:
+        t.write('\t'.join(COLUMNS) + '\n')
+        for r in rows:
+            t.write('\t'.join(str(r[c]) for c in COLUMNS) + '\n')
+
+    sys.stderr.write('pangenie_graph_vcf.py: %d records, %d ALT alleles, %d merged into an '
+                     'identical earlier allele, %d IDs replaced\n'
+                     % (record, len(rows), n_dup, n_renamed))
+
+
+def report(table, graph_vcf):
+    in_graph = set()
+    with open(graph_vcf) as g:
+        for line in g:
+            if line.startswith('#'):
+                continue
+            info = line.split('\t')[7]
+            for field in info.split(';'):
+                if field.startswith('ID='):
+                    for allele_ids in field[3:].split(','):
+                        in_graph.update(allele_ids.split(':'))
+
+    with open(table) as t:
+        header = t.readline().rstrip('\n').split('\t')
+        rows = [dict(zip(header, l.rstrip('\n').split('\t'))) for l in t]
+    missing = 0
+    for r in rows:
+        r['in_graph'] = 'yes' if r['graph_ID'] in in_graph else 'no'
+        missing += r['in_graph'] == 'no'
+    with open(table, 'w') as t:
+        t.write('\t'.join(header) + '\n')
+        for r in rows:
+            t.write('\t'.join(r[c] for c in header) + '\n')
+
+    # merge_vcfs.py leaves out overlapping alleles (every ALT sits on the same
+    # haplotype of the graph sample, so an overlap drops both), all but two
+    # ALT alleles at one position, and alleles with a base other than A, C, G
+    # or T.
+    sys.stderr.write('pangenie_graph_vcf.py: %d of %d pangenome.vcf alleles are not in the '
+                     'PanGenie graph and get no genotype\n' % (missing, len(rows)))
+
+
+if __name__ == '__main__':
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = p.add_subparsers(dest='cmd', required=True)
+    a = sub.add_parser('prepare')
+    a.add_argument('vcf_in', help='sites-only pangenome VCF')
+    a.add_argument('vcf_out', help='graph input VCF, one sample with GT 1|0')
+    a.add_argument('table', help='tracking table to write')
+    b = sub.add_parser('report')
+    b.add_argument('table', help='tracking table written by prepare, updated in place')
+    b.add_argument('graph_vcf', help='merge_vcfs.py output')
+    args = p.parse_args()
+    if args.cmd == 'prepare':
+        prepare(args.vcf_in, args.vcf_out, args.table)
+    else:
+        report(args.table, args.graph_vcf)

--- a/main.nf
+++ b/main.nf
@@ -1,17 +1,25 @@
-// SAY HELLO
+// The version stamped into VCF headers by concat_repeatmask, hervk_annotate
+// and merge_VCFs. Nextflow's strict syntax (the default parser from 26.04)
+// allows no statements outside a workflow, process or function, so the lookup
+// is a function and the workflow prints the banner.
+params.graffite_version = graffiteVersion()
 
-// 1. Read the version from the local file
-def versionFile = file("${baseDir}/version.txt")
-def pipelineVersion = versionFile.exists() && versionFile.text.trim() ? versionFile.text.trim() : '1.1.0'
+def graffiteVersion() {
+  def versionFile = file("${projectDir}/version.txt")
+  return versionFile.exists() && versionFile.text.trim() ? versionFile.text.trim() : '1.1.0'
+}
 
-// Expose version to process scripts (used for stamping VCF headers)
-params.graffite_version = pipelineVersion
+include { index_graph; bamtags_to_BED; lift_epigenome; annotate_VCF; annotate_BED; merge_BED; BED_to_graph; merge_CSV } from './panmethyl/module/'
 
-// 2. Define the revision (branch name)
-def pipelineRevision = workflow.revision ?: 'main'
+include { break_scaffold; map_asm; map_longreads; sniffles_sample_call; sniffles_population_call;
+         svim_asm; pav_asm; truvari_merge; split_repeatmask; concat_repeatmask; repeatmask_VCF; tsd_prep;
+         tsd_search; tsd_report; pangenie_index; pangenie; make_graph; bam_to_fastq;
+         graph_align_reads; vg_call; merge_VCFs; hervk_annotate;
+         hervk_reconcile } from './module'
 
-
-log.info """
+workflow {
+  // SAY HELLO
+  log.info """
 
 ▄████  ██▀███   ▄▄▄        █████▒ █████▒██▓▄▄▄█████▓▓█████
 ██▒ ▀█▒▓██ ▒ ██▒▒████▄    ▓██   ▒▓██           ██▒ ▓▒▓█   ▀
@@ -23,7 +31,7 @@ log.info """
 ░ ░   ░   ░░   ░   ░   ▒    ░ ░    ░ ░    ▒ ░  ░         ░
 ░    ░           ░  ░               ░              ░  ░
 
-V. ${pipelineVersion} - ${pipelineRevision}
+V. ${params.graffite_version} - ${workflow.revision ?: 'main'}
 
 Pangenomic Toolbox for the Analysis of Transposable Element Insertion Polymorphisms
 
@@ -32,15 +40,6 @@ Bug/issues: https://github.com/cgroza/GraffiTE/issues
 
 """
 
-include { index_graph; bamtags_to_BED; lift_epigenome; annotate_VCF; annotate_BED; merge_BED; BED_to_graph; merge_CSV } from './panmethyl/module/'
-
-include { break_scaffold; map_asm; map_longreads; sniffles_sample_call; sniffles_population_call;
-         svim_asm; pav_asm; truvari_merge; split_repeatmask; concat_repeatmask; repeatmask_VCF; tsd_prep;
-         tsd_search; tsd_report; pangenie_index; pangenie; make_graph; bam_to_fastq;
-         graph_align_reads; vg_call; merge_VCFs; hervk_annotate;
-         hervk_reconcile } from './module'
-
-workflow {
   // initiate channels that will provide the reference genome to processes
   Channel.fromPath(params.reference, checkIfExists:true).set{ref_asm_ch}
 
@@ -102,15 +101,15 @@ workflow {
     RM_ch = channel.empty()
     rm_dirs_ch = channel.empty()
     if(params.RM_dir){
-      channel.fromPath("${params.RM_dir}/*", type: "dir").
-      map{p -> [file("${p}/genotypes_repmasked_filtered.vcf", checkIfExists: true), file("${p}/repeatmasker_dir", checkIfExists: true)]}.
-      map{v -> [v[0], v[1]]}.set{RM_ch}
+      channel.fromPath("${params.RM_dir}/*", type: "dir")
+      .map{p -> [file("${p}/genotypes_repmasked_filtered.vcf", checkIfExists: true), file("${p}/repeatmasker_dir", checkIfExists: true)]}
+      .map{v -> [v[0], v[1]]}.set{RM_ch}
       // Built from params rather than by re-reading RM_ch, so the raw
       // RepeatMasker tables reach the HERV-K step without consuming a channel
       // that tsd_prep also needs.
-      channel.fromPath("${params.RM_dir}/*", type: "dir").
-      map{p -> file("${p}/repeatmasker_dir", checkIfExists: true)}.
-      collect().set{rm_dirs_ch}
+      channel.fromPath("${params.RM_dir}/*", type: "dir")
+      .map{p -> file("${p}/repeatmasker_dir", checkIfExists: true)}
+      .collect().set{rm_dirs_ch}
     } else {
       Channel.fromPath(params.TE_library, checkIfExists:true).set{TE_library_ch}
       // we need to set the vcf input depending what was given
@@ -125,11 +124,11 @@ workflow {
       repeatmask_VCF.out.vcf.set{RM_ch}
       repeatmask_VCF.out.vcf.map{v -> v[1]}.collect().set{rm_dirs_ch}
     }
-    tsd_report(tsd_search(tsd_prep(RM_ch.combine(ref_asm_ch)).
-                          splitText(elem: 3, by: params.tsd_batch_size, file: true)).
-               map{it -> [it[0], it[1], it[2], it[3].getText()]}.
-               groupTuple(by: 3).
-               map{v -> tuple(v[0], v[1], v[2][0], v[3])}
+    tsd_report(tsd_search(tsd_prep(RM_ch.combine(ref_asm_ch))
+                          .splitText(elem: 3, by: params.tsd_batch_size, file: true))
+               .map{it -> [it[0], it[1], it[2], it[3].getText()]}
+               .groupTuple(by: 3)
+               .map{v -> tuple(v[0], v[1], v[2][0], v[3])}
     )
     concat_repeatmask(tsd_report.out.vcf_ch.collect(),
                       tsd_report.out.tsd_full_group_ch.collect(),
@@ -158,21 +157,7 @@ workflow {
 
   if(params.genotype) {
     Channel.fromPath(params.genotype_with).splitCsv(header:true).map{ row ->
-      def parameter_preset = null
-      switch(row.type) {
-        case "pb":
-          parameter_preset = "hifi"
-          break
-        case "hifi":
-          parameter_preset = "hifi"
-          break
-        case "ont":
-          parameter_preset = "r10"
-          break
-        default:
-          parameter_preset = "default"
-          break
-      }
+      def parameter_preset = [pb: "hifi", hifi: "hifi", ont: "r10"].get(row.type, "default")
       [row.sample, file(row.path, checkIfExists:true), parameter_preset]
     }.branch{ it ->
         bam: it[1].extension == "bam"
@@ -217,7 +202,7 @@ workflow {
       }
 
       if(params.epigenomes) {
-        index_graph(graph_index_ch.map(p -> p / 'index.gfa'),
+        index_graph(graph_index_ch.map{p -> p / 'index.gfa'},
                     channel.value(params.motif)).set{indexed_graph_ch}
 
         lifted_mods_ch = channel.empty()

--- a/main.nf
+++ b/main.nf
@@ -184,7 +184,9 @@ workflow {
     indexed_vcfs = channel.empty()
     if(params.graph_method == "pangenie") {
       reads_ch.combine(pangenie_index(vcf_ch.combine(ref_asm_ch))).set{input_ch}
-      pangenie(input_ch, ref_asm_ch).set{indexed_vcfs}
+      // first() makes the reference a value channel. As a queue channel it
+      // held one item, so pangenie ran for one sample and stopped.
+      pangenie(input_ch, ref_asm_ch.first()).set{indexed_vcfs}
     } else if(params.graph_method == "giraffe" || params.graph_method == "graphaligner" || params.graph_method == "precomputed") {
       graph_method = channel.value(params.graph_method)
 

--- a/main.nf
+++ b/main.nf
@@ -183,7 +183,8 @@ workflow {
 
     indexed_vcfs = channel.empty()
     if(params.graph_method == "pangenie") {
-      reads_ch.combine(pangenie_index(vcf_ch.combine(ref_asm_ch))).set{input_ch}
+      pangenie_index(vcf_ch.combine(ref_asm_ch))
+      reads_ch.combine(pangenie_index.out.index).set{input_ch}
       // first() makes the reference a value channel. As a queue channel it
       // held one item, so pangenie ran for one sample and stopped.
       pangenie(input_ch, ref_asm_ch.first()).set{indexed_vcfs}

--- a/module/main.nf
+++ b/module/main.nf
@@ -227,7 +227,7 @@ process truvari_merge {
     tabix truvari_merged.vcf.gz
     rm unsorted.vcf.gz
 
-    bcftools +setGT truvari_merged.vcf -- -t . -n 0 | bcftools norm -f ${ref} | \
+    bcftools +setGT truvari_merged.vcf.gz -- -t . -n 0 | bcftools norm -f ${ref} | \
     bcftools +fill-tags - -Ov -o truvari_merged_filled.vcf -- -t 'SVLEN=strlen(ALT)-strlen(REF)'
     shorten_ids.py --vcf_in  truvari_merged_filled.vcf --vcf_out SVs.vcf
   fi

--- a/module/main.nf
+++ b/module/main.nf
@@ -664,21 +664,26 @@ process tsd_report {
   """
 }
 
+// pangenie_graph_variants.tsv lists each ALT allele of pangenome.vcf with its
+// ID in the graph and whether merge_vcfs.py kept it. PanGenie writes the graph
+// ID to INFO/ID of the genotyped VCFs.
 process pangenie_index {
+  publishDir "${params.out}/4_Genotyping", mode: 'copy', pattern: 'pangenie_graph_variants.tsv'
+
   input:
   tuple path(vcf), path(ref)
 
   output:
-  path("pangenie_index")
+  path("pangenie_index"), emit: index
+  path("pangenie_graph_variants.tsv"), emit: table
 
   script:
   """
-  bcftools view -G ${vcf} | \
-    awk -v FS='\t' -v OFS='\t' \
-    '{if(\$0 ~ /#CHROM/) {\$9 = "FORMAT"; \$10 = "ref"; print \$0} else if(substr(\$0, 1, 1) == "#") {print \$0} else {\$9 = "GT"; \$10 = "1|0"; print \$0}}' | \
-    awk 'NR==1{print; print "##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">"} NR!=1' | \
-    bcftools norm -m+ -Ov -o graph.vcf
+  bcftools view -G -Ov -o sites.vcf ${vcf}
+  pangenie_graph_vcf.py prepare sites.vcf graph_input.vcf pangenie_graph_variants.tsv
+  bcftools sort graph_input.vcf | bcftools norm -m+ -Ov -o graph.vcf
   merge_vcfs.py merge -r ${ref} -v graph.vcf -ploidy 2 > graph_merged.vcf
+  pangenie_graph_vcf.py report pangenie_graph_variants.tsv graph_merged.vcf
   mkdir pangenie_index
   PanGenie-index -v graph_merged.vcf -r ${ref} -t ${task.cpus} -o pangenie_index/pangenie_index
   """

--- a/module/main.nf
+++ b/module/main.nf
@@ -92,6 +92,7 @@ process sniffles_population_call {
   output:
   path("sniffles2_individual_VCFs/*.vcf.gz")
 
+  script:
   """
   ls *.snf > snfs.tsv
   sniffles --minsvlen 100  --threads ${task.cpus} --reference ${ref} --input snfs.tsv --vcf genotypes_unfiltered.vcf
@@ -489,12 +490,12 @@ process concat_repeatmask {
   // fields, and anchoring with ^ applies per element. Prefixes only: repeat_ids
   // carry "(x)" and "(VNTR_only)" suffixes from bin/annotate_vcf.R.
   def orIds = { csv -> '(' + csv.toString().split(',').collect{ "repeat_ids~\"${it.trim()}\"" }.join(' | ') + ')' }
-  def grp   = { cls, csv -> csv?.toString()?.trim() ? "(matching_classes=\"${cls}\" & ${orIds(csv)})" : "matching_classes=\"${cls}\"" }
-  def human_ids = [grp('SINE/Alu',       params.human_alu_ids),
-                   grp('LINE/L1',        params.human_l1_ids),
-                   grp('Retroposon/SVA', params.human_sva_ids),
-                   grp('Simple_repeat',  params.human_sva_ids),
-                   grp('LTR/ERVK',       params.human_hervk_ids)].join(' | ')
+  def grp   = { cls, csv -> csv?.toString()?.trim() ? "(matching_classes=\"${cls}\" & ${orIds.call(csv)})" : "matching_classes=\"${cls}\"" }
+  def human_ids = [grp.call('SINE/Alu',       params.human_alu_ids),
+                   grp.call('LINE/L1',        params.human_l1_ids),
+                   grp.call('Retroposon/SVA', params.human_sva_ids),
+                   grp.call('Simple_repeat',  params.human_sva_ids),
+                   grp.call('LTR/ERVK',       params.human_hervk_ids)].join(' | ')
   def human_size   = "abs(SVLEN)>=${params.human_min_svlen} & (ULTRA_TR_span<${params.human_max_ultra_span} | matching_classes=\"Simple_repeat\")"
   // polyA (TPRT signature) is required for Alu/L1/SVA but not for HML-2 or for
   // SVA-VNTR expansions. Stated positively: bcftools "!~" does not negate
@@ -589,7 +590,7 @@ process concat_repeatmask {
 }
 
 process repeatmask_VCF {
-  publishDir "${params.out}/2_Repeat_Filtering/${task.index}", mode: 'copy'
+  publishDir path: { "${params.out}/2_Repeat_Filtering/${task.index}" }, mode: 'copy'
 
   input:
   tuple path("genotypes.vcf"), path(TE_library), path(ref_fasta)
@@ -720,26 +721,27 @@ process make_graph {
   path("index")
 
   script:
-  prep = """
+  def prep = """
   mkdir index
   bcftools +setGT ${vcf} -- -t a -n u > unphased.vcf
   """
-  switch(graph_method) {
-    case "giraffe":
-      prep + """
-      vg autoindex --tmp-dir \$PWD  -p index/index -w sr-giraffe -w lr-giraffe -v unphased.vcf -r ${fasta}
-      vg convert --vg-algorithm -f index/index.giraffe.gbz > index/index.gfa
-      vg snarls index/index.giraffe.gbz > index/index.pb
-      """
-      break
-    case "graphaligner":
-      prep + """
-      export TMPDIR=$PWD
-      vg construct -a  -r ${fasta} -v unphased.vcf -m 1024 > index/index.vg
-      vg convert --vg-algorithm -f index/index.vg > index/index.gfa
-      vg snarls index/index.gfa > index/index.pb
-      """
-      break
+  if(graph_method == "giraffe") {
+    prep + """
+    vg autoindex --tmp-dir \$PWD  -p index/index -w sr-giraffe -w lr-giraffe -v unphased.vcf -r ${fasta}
+    vg convert --vg-algorithm -f index/index.giraffe.gbz > index/index.gfa
+    vg snarls index/index.giraffe.gbz > index/index.pb
+    """
+  }
+  else if(graph_method == "graphaligner") {
+    prep + """
+    export TMPDIR=\$PWD
+    vg construct -a  -r ${fasta} -v unphased.vcf -m 1024 > index/index.vg
+    vg convert --vg-algorithm -f index/index.vg > index/index.gfa
+    vg snarls index/index.gfa > index/index.pb
+    """
+  }
+  else {
+    error "make_graph has no recipe for --graph_method ${graph_method}"
   }
 }
 
@@ -772,28 +774,29 @@ process graph_align_reads {
 
   script:
 
-  interleaved = "-i"
+  def interleaved = "-i"
   if(preset != "default") {
     interleaved = ""
   }
 
-  switch(graph_method) {
-    case "giraffe":
-      """
-      vg giraffe --parameter-preset ${preset} -o gam -t ${task.cpus} --index-basename index/index ${interleaved} -f ${sample_reads} > ${sample_name}.gam
-      vg pack -x index/index.giraffe.gbz -g ${sample_name}.gam -o ${sample_name}.pack -Q ${params.min_mapq}
-      vg convert -G ${sample_name}.gam index/index.giraffe.gbz | subset_gaf.py | sort -k1b,1 | gzip > ${sample_name}.gaf.gz
-      rm ${sample_name}.gam
-      """
-      break
-    case "graphaligner":
-      """
-      GraphAligner -t ${task.cpus} -x vg -g index/index.gfa -f ${sample_reads} -a ${sample_name}.gam
-      vg pack -x index/index.gfa -g ${sample_name}.gam -o ${sample_name}.pack -Q ${params.min_mapq}
-      vg convert -G ${sample_name}.gam index/index.gfa | subset_gaf.py | sort -k1b,1 | gzip > ${sample_name}.gaf.gz
-      rm ${sample_name}.gam
-      """
-      break
+  if(graph_method == "giraffe") {
+    """
+    vg giraffe --parameter-preset ${preset} -o gam -t ${task.cpus} --index-basename index/index ${interleaved} -f ${sample_reads} > ${sample_name}.gam
+    vg pack -x index/index.giraffe.gbz -g ${sample_name}.gam -o ${sample_name}.pack -Q ${params.min_mapq}
+    vg convert -G ${sample_name}.gam index/index.giraffe.gbz | subset_gaf.py | sort -k1b,1 | gzip > ${sample_name}.gaf.gz
+    rm ${sample_name}.gam
+    """
+  }
+  else if(graph_method == "graphaligner") {
+    """
+    GraphAligner -t ${task.cpus} -x vg -g index/index.gfa -f ${sample_reads} -a ${sample_name}.gam
+    vg pack -x index/index.gfa -g ${sample_name}.gam -o ${sample_name}.pack -Q ${params.min_mapq}
+    vg convert -G ${sample_name}.gam index/index.gfa | subset_gaf.py | sort -k1b,1 | gzip > ${sample_name}.gaf.gz
+    rm ${sample_name}.gam
+    """
+  }
+  else {
+    error "graph_align_reads has no recipe for --graph_method ${graph_method}"
   }
 }
 

--- a/test/pangenie_93/handout/INPUTS.env
+++ b/test/pangenie_93/handout/INPUTS.env
@@ -1,0 +1,48 @@
+# PanGenie test for issue #93. See README_HPC_CLAUDE.md.
+#
+# Fill in the paths below, then run ./preflight.sh
+# All paths must be ABSOLUTE: nextflow.config runs the container with
+# --contain, so a relative path resolves to nothing inside it and the run
+# fails late, after the allocation is already spent.
+
+# pangenome.vcf from the #93 reporter (51,910 records, 31 duplicate pairs).
+# Use the ORIGINAL file, not a deduplicated copy: the duplicates are what the
+# fix has to handle. Plain .vcf or .vcf.gz.
+GRAFFITE_VCF=""
+
+# The reference the pangenome.vcf was called against (EptFus1.0, the
+# mEF_genomic.fa of the issue log). A .fai beside it helps but is not required.
+REFERENCE=""
+
+# Short reads for one sample, as a FASTQ (interleaved pairs are fine; PanGenie
+# counts k-mers and ignores pairing). Plain or gzipped.
+READS_1=""
+
+# Optional second read set. When empty, READS_1 is used again under a second
+# sample name, which is enough to show that pangenie runs once per sample
+# (the "1 of 6 samples" half of #93) at twice the genotyping cost.
+READS_2=""
+
+# ---- optional, sensible defaults ----
+
+# Local .sif to pin the container. Leave empty to let Nextflow pull
+# library://cgroza/collection/graffite:latest itself.
+GRAFFITE_SIF=""
+
+OUTDIR="pangenie_93_run"
+PROFILE="cluster"          # slurm. Use "standard" only for a local smoke test.
+CPUS="16"                  # --cores: threads for pangenie_index and pangenie
+# nextflow.config leaves pangenie_memory unset, which hands memory to the slurm
+# default. PanGenie-index on a ~2 Gb genome needs tens of GB.
+PANGENIE_MEMORY="120G"
+PANGENIE_TIME="24h"
+
+# Sample names written into reads.csv and expected in the output.
+SAMPLE_1="S1"
+SAMPLE_2="S2"
+
+# GraffiTE revision. Nextflow caches the repo under ~/.nextflow/assets/.
+# bootstrap.sh keeps an INPUTS.env that is already here, so carrying one over
+# from an earlier run also carries its old REVISION.
+REVISION="fix/pangenie-dup-ids-93"
+PROJECT="cgroza/GraffiTE"

--- a/test/pangenie_93/handout/README_HPC_CLAUDE.md
+++ b/test/pangenie_93/handout/README_HPC_CLAUDE.md
@@ -1,0 +1,123 @@
+# Issue #93 PanGenie test — handout
+
+You are running one test on a cluster and reporting what came back. Everything
+needed is in this directory. Read this file top to bottom before starting.
+
+## What is being tested
+
+Issue #93 (https://github.com/cgroza/GraffiTE/issues/93) reported two failures
+on the v1.1dev PanGenie path. Branch `fix/pangenie-dup-ids-93` fixes both:
+
+1. **`pangenie_index` crashed** in `merge_vcfs.py` with
+   `An ID needs to be provided for each individual ID`. The reporter's
+   `pangenome.vcf` has 31 pairs of records with the same CHROM/POS/REF/ALT and
+   different IDs; `bcftools norm -m+` joined each pair into one ALT with two
+   IDs. The new `bin/pangenie_graph_vcf.py` merges such records into one graph
+   variant before `norm`, and writes `4_Genotyping/pangenie_graph_variants.tsv`:
+   one row per ALT allele of `pangenome.vcf`, with its graph ID (which PanGenie
+   copies to INFO/ID of the genotyped VCFs) and whether it made it into the
+   graph.
+2. **Only 1 of 6 samples was genotyped.** `pangenie` received the reference as
+   a one-item queue channel, so it ran once. It now gets a value channel.
+
+Also on the branch, not exercised by this run's inputs except where noted:
+
+- `truvari_merge` with two or more discovery VCFs read a file that no longer
+  existed (not exercised: this run starts from `--graffite_vcf`).
+- The workflow did not compile under Nextflow 26's strict syntax.
+  **Exercised** if the site's Nextflow is 26.x (strict syntax is its default),
+  and `preflight.sh` runs `nextflow lint` when the site's Nextflow has it.
+
+Until now, `PanGenie-index` and `PanGenie` have not run on this branch: the
+fixes were tested locally without the container. This run is the first time
+the whole PanGenie path executes on the fixed code.
+
+## The one thing not to do
+
+**Do not deduplicate or otherwise edit `pangenome.vcf`.** The reporter worked
+around the crash by deduplicating it; the point here is that the pipeline
+handles the original file. `preflight.sh` warns if the file has no duplicates.
+
+## Inputs
+
+Everything is driven by **`INPUTS.env`**. Populate the paths at the top:
+
+| variable | what |
+|---|---|
+| `GRAFFITE_VCF` | the reporter's `pangenome.vcf` (original, 51,910 records) |
+| `REFERENCE` | the reference it was called against (EptFus1.0, `mEF_genomic.fa` in the issue log) |
+| `READS_1` | one short-read FASTQ (interleaved is fine) |
+| `READS_2` | optional second read set; empty reuses `READS_1` as a second sample |
+| `GRAFFITE_SIF` | optional local `.sif`; empty lets Nextflow pull the image |
+| `OUTDIR`, `PROFILE`, `CPUS` | defaults `pangenie_93_run`, `cluster`, `16` |
+| `PANGENIE_MEMORY`, `PANGENIE_TIME` | defaults `120G`, `24h` (the config leaves memory unset) |
+| `REVISION` | `fix/pangenie-dup-ids-93` |
+
+All paths must be **absolute** (`--contain` in `nextflow.config`).
+
+## Run it
+
+```bash
+mkdir -p /xdisk/cgoubert/cgoubert/GraffiTE1.1/issue93 && cd $_
+module load nextflow            # whatever the site provides
+
+# first time only: fetch the handout out of the Nextflow asset cache
+nextflow pull cgroza/GraffiTE -r fix/pangenie-dup-ids-93
+cp ~/.nextflow/assets/cgroza/GraffiTE/test/pangenie_93/handout/* .
+
+./bootstrap.sh                  # nextflow pull + refresh this handout
+$EDITOR INPUTS.env              # fill in the paths
+./preflight.sh                  # stop here if it fails
+./run_pangenie_test.sh          # pipeline, then assertions
+./bundle_results.sh             # -> pangenie_93_results_<date>.tar.gz
+```
+
+Run under `tmux`/`screen` or as a batch job: with `-profile cluster` Nextflow
+submits its own slurm jobs and the driver must stay alive.
+
+Expected work: `pangenie_index` once (graph of ~50,000 variants on a ~2 Gb
+genome), then `pangenie` once **per sample** — two tasks. If the trace shows
+one `pangenie` task, the second fix did not take; report it.
+
+`run_pangenie_test.sh` passes `-latest` and `-resume`, and drops `-resume` when
+the pipeline commit moves (Nextflow does not hash `bin/`, so a resumed
+`pangenie_index` could come from the old `pangenie_graph_vcf.py`).
+
+## What must pass
+
+`assert_pangenie_test.py` exits non-zero on any `[FAIL]`:
+
+- the table, the merged VCF and both `<sample>_genotyping.vcf.gz` exist
+- one table row per ALT allele of `pangenome.vcf`; 31 duplicate rows for the
+  #93 file, each sharing the graph ID of its first occurrence
+- no graph ID empty or holding `; , : = |`
+- both samples are columns of `GraffiTE.merged.genotypes.vcf.gz`
+- the graph IDs in INFO/ID of each per-sample VCF and of the merged VCF are
+  exactly the table's `in_graph=yes` graph IDs
+
+## Reading a failure
+
+| symptom | what it means |
+|---|---|
+| `pangenie_index` fails with `An ID needs to be provided` | the old script ran: check `REVISION`, the cached commit, and that `-resume` was dropped |
+| `pangenie_graph_vcf.py: command not found` or permission denied | `bin/pangenie_graph_vcf.py` lost its executable bit; report the `ls -l` of it in the asset dir |
+| only one `<sample>_genotyping.vcf.gz` / one `pangenie` task | the value-channel fix did not take |
+| PanGenie-index killed / exit 137 / 140 | memory or time; raise `PANGENIE_MEMORY` / `PANGENIE_TIME` and rerun (resume is fine) |
+| INFO/ID set differs from the table | report the counts in that line and the first few IDs on each side; do not edit anything |
+| compile error mentioning syntax | report `nextflow -v` and the error verbatim; this is the Nextflow 26 fix |
+
+## What to report back
+
+Send the bundle plus a short summary:
+
+- the assertion log verbatim, including every `NOTE:` line
+- `nextflow -v`, and whether it ran with the strict parser (26.x default) or not
+- the `pangenie_graph_vcf.py:` lines from the `pangenie_index` `.command.err`
+  in the bundle (records, duplicates merged, IDs replaced, alleles not in graph)
+- the `in_graph=no` count against the predicted 1,569 (`NOTE` line). This is a
+  prediction from a stand-in reference, not a test; report it either way
+- wall time and peak memory of `pangenie_index` and each `pangenie` task
+  (from `nextflow_trace.txt` / the report)
+
+Do not tune parameters to make assertions pass. If something disagrees, that is
+the result.

--- a/test/pangenie_93/handout/assert_pangenie_test.py
+++ b/test/pangenie_93/handout/assert_pangenie_test.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Assertions for the #93 PanGenie test. Standard library only.
+
+FAIL lines decide the result (exit 1 on any). NOTE lines are measurements to
+report back verbatim; they are not pass/fail.
+"""
+import argparse
+import collections
+import gzip
+import os
+import sys
+
+# Measured on the #93 pangenome.vcf before this test was written, with
+# merge_vcfs.py run against a stand-in reference (every base A): 1,550 alleles
+# with N in ALT and 19 in overlapping clusters. The real reference is expected
+# to give the same number, but that is a prediction, so a mismatch is a NOTE.
+ISSUE93 = {'records': 51910, 'duplicates': 31, 'not_in_graph': 1569}
+RESERVED = set(';,:=| \t')
+
+fails = 0
+
+
+def ok(msg):
+    print('  [ ok ] ' + msg)
+
+
+def fail(msg):
+    global fails
+    fails += 1
+    print('  [FAIL] ' + msg)
+
+
+def note(msg):
+    print('  NOTE: ' + msg)
+
+
+def open_any(path):
+    return gzip.open(path, 'rt') if path.endswith('.gz') else open(path)
+
+
+def read_vcf(path):
+    """Return (sample names, list of (chrom, pos, id, ref, alt, info, gts))."""
+    samples, recs = [], []
+    with open_any(path) as f:
+        for line in f:
+            if line.startswith('##'):
+                continue
+            fields = line.rstrip('\n').split('\t')
+            if line.startswith('#'):
+                samples = fields[9:]
+                continue
+            gts = []
+            if len(fields) > 9:
+                fmt = fields[8].split(':')
+                gi = fmt.index('GT') if 'GT' in fmt else None
+                gts = [s.split(':')[gi] if gi is not None else '.' for s in fields[9:]]
+            recs.append((fields[0], fields[1], fields[2], fields[3], fields[4], fields[7], gts))
+    return samples, recs
+
+
+def info_ids(info):
+    for field in info.split(';'):
+        if field.startswith('ID='):
+            out = []
+            for allele in field[3:].split(','):
+                out.extend(allele.split(':'))
+            return out
+    return []
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('--outdir', required=True)
+    p.add_argument('--graffite-vcf', required=True)
+    p.add_argument('--samples', required=True, help='comma-separated')
+    p.add_argument('--distinct-reads', action='store_true',
+                   help='the samples have different reads (skips the same-reads concordance note)')
+    a = p.parse_args()
+    samples = a.samples.split(',')
+    gdir = os.path.join(a.outdir, '4_Genotyping')
+
+    print('== outputs ==')
+    table_path = os.path.join(gdir, 'pangenie_graph_variants.tsv')
+    merged_path = os.path.join(gdir, 'GraffiTE.merged.genotypes.vcf.gz')
+    per_sample = {s: os.path.join(gdir, s + '_genotyping.vcf.gz') for s in samples}
+    missing = [x for x in [table_path, merged_path] + list(per_sample.values()) if not os.path.exists(x)]
+    for x in [table_path, merged_path] + list(per_sample.values()):
+        (ok if os.path.exists(x) else fail)(('found ' if os.path.exists(x) else 'missing ') + x)
+    if missing:
+        print('\nstopping: outputs missing (did the run finish? see nextflow_trace.txt)')
+        return 1
+
+    print('== tracking table vs pangenome.vcf ==')
+    _, pan = read_vcf(a.graffite_vcf)
+    alleles, first_of, dup_pairs = [], {}, []
+    for n, (c, pos, vid, ref, alts, _, _) in enumerate(pan, start=1):
+        for i, alt in enumerate(alts.split(','), start=1):
+            key = (c, pos, ref, alt)
+            if key in first_of:
+                dup_pairs.append(((str(n), str(i)), first_of[key]))
+            else:
+                first_of[key] = (str(n), str(i))
+            alleles.append((n, vid, key))
+    dup_expect = len(dup_pairs)
+    with open(table_path) as t:
+        header = t.readline().rstrip('\n').split('\t')
+        rows = [dict(zip(header, l.rstrip('\n').split('\t'))) for l in t]
+    want_cols = ['record', 'CHROM', 'POS', 'pangenome_ID', 'allele', 'graph_ID', 'in_graph', 'note']
+    (ok if header == want_cols else fail)('table columns: ' + ','.join(header))
+    (ok if len(rows) == len(alleles) else fail)(
+        '%d table rows for %d ALT alleles in pangenome.vcf' % (len(rows), len(alleles)))
+
+    dups = [r for r in rows if r['note'].startswith('duplicate_of_record_')]
+    (ok if len(dups) == dup_expect else fail)(
+        '%d duplicate rows, %d duplicate alleles counted in pangenome.vcf' % (len(dups), dup_expect))
+    by_rec = {(r['record'], r['allele']): r for r in rows}
+    bad_dup = [d for d, first in dup_pairs
+               if by_rec.get(d, {}).get('graph_ID') is None
+               or by_rec[d]['graph_ID'] != by_rec.get(first, {}).get('graph_ID')]
+    (ok if not bad_dup else fail)(
+        'every duplicate allele shares the graph_ID of its first occurrence (%d do not)' % len(bad_dup))
+
+    replaced = [r for r in rows if r['note'] == 'id_replaced']
+    note('%d IDs replaced (0 expected for the #93 file, which has no missing or repeated IDs)' % len(replaced))
+    bad_ids = [r['graph_ID'] for r in rows if set(r['graph_ID']) & RESERVED or r['graph_ID'] in ('', '.')]
+    (ok if not bad_ids else fail)('no graph_ID contains a reserved character or is empty (%d do)' % len(bad_ids))
+
+    yes = {r['graph_ID'] for r in rows if r['in_graph'] == 'yes'}
+    no_rows = [r for r in rows if r['in_graph'] == 'no']
+    note('%d of %d alleles in_graph=no; %d distinct graph IDs in the graph'
+         % (len(no_rows), len(rows), len(yes)))
+    if len(pan) == ISSUE93['records'] and dup_expect == ISSUE93['duplicates']:
+        msg = 'in_graph=no is %d; predicted %d from the stand-in reference run' % (len(no_rows), ISSUE93['not_in_graph'])
+        note(msg + (' (matches)' if len(no_rows) == ISSUE93['not_in_graph'] else ' (DIFFERS -- report this)'))
+
+    print('== every sample genotyped (the "1 of 6 samples" half of #93) ==')
+    msamples, merged = read_vcf(merged_path)
+    for s in samples:
+        (ok if s in msamples else fail)('%s is a sample column of the merged VCF' % s)
+    (ok if len(msamples) == len(samples) else fail)(
+        'merged VCF has %d sample columns, %d samples in reads.csv' % (len(msamples), len(samples)))
+
+    print('== graph IDs reach the genotyped VCFs ==')
+    for s, path in per_sample.items():
+        _, recs = read_vcf(path)
+        got = set()
+        for r in recs:
+            got.update(info_ids(r[5]))
+        (ok if got == yes else fail)(
+            '%s: INFO/ID holds %d graph IDs, table has %d in_graph=yes (%d only in VCF, %d only in table)'
+            % (s, len(got), len(yes), len(got - yes), len(yes - got)))
+    got = set()
+    for r in merged:
+        got.update(info_ids(r[5]))
+    (ok if got == yes else fail)(
+        'merged VCF: INFO/ID holds %d graph IDs, table has %d in_graph=yes (%d only in VCF, %d only in table)'
+        % (len(got), len(yes), len(got - yes), len(yes - got)))
+    dup_gids = {r['graph_ID'] for r in dups if r['in_graph'] == 'yes'}
+    (ok if dup_gids <= got else fail)(
+        '%d of %d duplicate groups in the graph have a genotyped record' % (len(dup_gids & got), len(dup_gids)))
+
+    print('== measurements ==')
+    pan_ids_of = collections.defaultdict(set)
+    for r in rows:
+        pan_ids_of[r['graph_ID']].add(r['pangenome_ID'])
+    match = sum(1 for r in merged if any(r[2] in pan_ids_of.get(g, ()) for g in info_ids(r[5])))
+    note('merged VCF: %d records; %d have an ID column that is one of the pangenome IDs of their graph_ID'
+         % (len(merged), match))
+    for i, s in enumerate(msamples):
+        c = collections.Counter(r[6][i].replace('|', '/') for r in merged)
+        note('%s genotypes: %s' % (s, ', '.join('%s=%d' % kv for kv in c.most_common())))
+    if len(msamples) == 2 and not a.distinct_reads:
+        same = sum(1 for r in merged if r[6][0].replace('|', '/') == r[6][1].replace('|', '/'))
+        note('same reads under two names: %d of %d genotypes identical' % (same, len(merged)))
+
+    print()
+    print('RESULT: %s (%d failure%s)' % ('PASS' if fails == 0 else 'FAIL', fails, '' if fails == 1 else 's'))
+    return 1 if fails else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/test/pangenie_93/handout/bootstrap.sh
+++ b/test/pangenie_93/handout/bootstrap.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Fetch the GraffiTE revision and drop this handout into the current directory.
+# Run this first, from the directory you want to work in.
+set -euo pipefail
+_env_rev=""; _env_proj=""
+if [[ -f ./INPUTS.env ]]; then
+  # shellcheck disable=SC1091
+  _env_rev="$(source ./INPUTS.env >/dev/null 2>&1; echo "${REVISION:-}")"
+  _env_proj="$(source ./INPUTS.env >/dev/null 2>&1; echo "${PROJECT:-}")"
+fi
+PROJECT="${PROJECT:-${_env_proj:-cgroza/GraffiTE}}"
+REVISION="${REVISION:-${_env_rev:-fix/pangenie-dup-ids-93}}"
+
+command -v nextflow >/dev/null || {
+  echo "nextflow not on PATH -- module load it first (e.g. 'module load nextflow')" >&2
+  exit 1; }
+
+echo "pulling $PROJECT -r $REVISION ..."
+nextflow pull "$PROJECT" -r "$REVISION"
+
+ASSET="${NXF_ASSETS:-$HOME/.nextflow/assets}/$PROJECT"
+SRC="$ASSET/test/pangenie_93/handout"
+[[ -d "$SRC" ]] || { echo "handout not found at $SRC" >&2; exit 1; }
+
+# Never clobber a populated INPUTS.env, and never silently discard a local edit.
+for f in "$SRC"/*; do
+  b="$(basename "$f")"
+  if [[ "$b" == "INPUTS.env" && -f ./INPUTS.env ]]; then
+    echo "  keeping your existing INPUTS.env (new template at INPUTS.env.new)"
+    cp "$f" ./INPUTS.env.new
+  elif [[ -f "./$b" ]] && ! cmp -s "$f" "./$b"; then
+    cp "./$b" "./$b.local.bak"
+    cp "$f" ./
+    echo "  $b differed -- yours saved as $b.local.bak"
+  else
+    cp "$f" ./
+  fi
+done
+chmod +x ./*.sh ./*.py 2>/dev/null || true
+
+echo
+echo "handout ready in $PWD"
+echo "revision: $(cd "$ASSET" && git rev-parse --short HEAD 2>/dev/null || echo '?') on $REVISION"
+echo
+echo "next: edit INPUTS.env, then ./preflight.sh"

--- a/test/pangenie_93/handout/bundle_results.sh
+++ b/test/pangenie_93/handout/bundle_results.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Pack the #93 PanGenie test outputs into one archive to bring back.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+# shellcheck disable=SC1091
+[[ -f INPUTS.env ]] && source ./INPUTS.env
+OUTDIR="${1:-${OUTDIR:-pangenie_93_run}}"
+BUNDLE="pangenie_93_results_$(date +%Y%m%d)"
+rm -rf "$BUNDLE" && mkdir -p "$BUNDLE"
+
+for f in "$OUTDIR"/4_Genotyping/pangenie_graph_variants.tsv \
+         "$OUTDIR"/4_Genotyping/GraffiTE.merged.genotypes.vcf.gz \
+         "$OUTDIR"/4_Genotyping/*_genotyping.vcf.gz \
+         "$OUTDIR"/pangenie_93_assertions.log \
+         "$OUTDIR"/nextflow_report.html \
+         "$OUTDIR"/nextflow_trace.txt \
+         "$OUTDIR"/reads.csv; do
+  [[ -f "$f" ]] && cp "$f" "$BUNDLE/" || echo "  (missing: $f)"
+done
+
+# The pangenie_index task logs hold the pangenie_graph_vcf.py counts (records,
+# duplicates merged, IDs replaced, alleles left out of the graph) and the
+# merge_vcfs.py messages. Find the task directory through the trace.
+WORK="${NXF_WORK:-work}"
+if [[ -f "$OUTDIR/nextflow_trace.txt" ]]; then
+  awk -F'\t' 'NR==1 {for(i=1;i<=NF;i++) col[$i]=i; next}
+              $col["name"] ~ /^pangenie_index/ || $col["name"] ~ /^pangenie / {print $col["name"] "\t" $col["hash"] "\t" $col["status"] "\t" $col["exit"]}' \
+      "$OUTDIR/nextflow_trace.txt" > "$BUNDLE/pangenie_tasks.tsv" || true
+  while IFS=$'\t' read -r name hash status rc; do
+    d=$(ls -d "$WORK/$hash"* 2>/dev/null | head -1) || true
+    [[ -n "$d" ]] || continue
+    tag=$(echo "$name" | tr -c 'A-Za-z0-9_\n' '_')
+    for x in .command.sh .command.err .command.out .exitcode; do
+      [[ -f "$d/$x" ]] && cp "$d/$x" "$BUNDLE/${tag}${x}"
+    done
+  done < "$BUNDLE/pangenie_tasks.tsv"
+fi
+
+GT_DIR="${NXF_ASSETS:-$HOME/.nextflow/assets}/${PROJECT:-cgroza/GraffiTE}"
+{
+  echo "date        : $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "host        : $(hostname)"
+  echo "nextflow    : $(nextflow -v 2>/dev/null | head -1)"
+  echo "project     : ${PROJECT:-cgroza/GraffiTE} -r ${REVISION:-?}"
+  echo "commit      : $(cd "$GT_DIR" 2>/dev/null && git rev-parse HEAD 2>/dev/null || echo '?')"
+  echo "graffite_vcf: ${GRAFFITE_VCF:-<unset>}"
+  echo "reference   : ${REFERENCE:-<unset>}"
+  echo "reads_1     : ${READS_1:-<unset>}"
+  echo "reads_2     : ${READS_2:-<same as reads_1>}"
+  echo "sif         : ${GRAFFITE_SIF:-<pulled by nextflow>}"
+} > "$BUNDLE/RUN_INFO.txt"
+
+tar czf "${BUNDLE}.tar.gz" "$BUNDLE" && rm -rf "$BUNDLE"
+echo "wrote ${BUNDLE}.tar.gz ($(du -h "${BUNDLE}.tar.gz" | cut -f1))"

--- a/test/pangenie_93/handout/preflight.sh
+++ b/test/pangenie_93/handout/preflight.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# Pre-flight for the #93 PanGenie test. Checks inputs, tools and the cached
+# revision before committing a cluster allocation.
+set -uo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+if [[ -f INPUTS.env ]]; then
+  # shellcheck disable=SC1091
+  source ./INPUTS.env
+else
+  echo "INPUTS.env not found -- run ./bootstrap.sh first" >&2; exit 1
+fi
+fail=0
+ok(){   printf '  [ ok ] %s\n' "$1"; }
+bad(){  printf '  [FAIL] %s\n' "$1"; fail=1; }
+warn(){ printf '  [warn] %s\n' "$1"; }
+cat_any(){ case "$1" in *.gz) gzip -cd "$1" ;; *) cat "$1" ;; esac; }
+
+echo "== inputs =="
+for var in GRAFFITE_VCF REFERENCE READS_1; do
+  val="${!var:-}"
+  if   [[ -z "$val"   ]]; then bad "$var is not set"
+  elif [[ ! -f "$val" ]]; then bad "$var=$val does not exist"
+  elif [[ "$val" != /* ]]; then bad "$var=$val is relative -- use an absolute path"
+  else ok "$var=$val ($(du -h "$val" | cut -f1))"; fi
+done
+if [[ -n "${READS_2:-}" ]]; then
+  [[ -f "$READS_2" && "$READS_2" == /* ]] && ok "READS_2=$READS_2" || bad "READS_2=$READS_2 missing or relative"
+else
+  warn "READS_2 empty -- READS_1 is genotyped twice, as ${SAMPLE_1:-S1} and ${SAMPLE_2:-S2}"
+fi
+[[ -n "${REFERENCE:-}" && -f "${REFERENCE}.fai" ]] \
+  && ok "reference index ${REFERENCE}.fai" \
+  || warn "no ${REFERENCE:-<REFERENCE>}.fai -- contig check skipped; the pipeline builds one"
+
+echo "== pangenome VCF =="
+if [[ -f "${GRAFFITE_VCF:-}" ]]; then
+  # Expected for the #93 file: 51910 records, 31 duplicate CHROM/POS/REF/ALT
+  # keys, 0 missing IDs. A deduplicated copy (0 duplicates) makes the test
+  # vacuous for the fix, so it is flagged.
+  read -r n_rec n_dup n_dot n_multi < <(cat_any "$GRAFFITE_VCF" | awk -F'\t' '
+    /^#/ {next}
+    {n++; k=$1"\t"$2"\t"$4"\t"$5; c[k]++; if(c[k]==2) d++; if($3==".") dot++; if($5 ~ /,/) m++}
+    END {print n+0, d+0, dot+0, m+0}')
+  ok "$n_rec records, $n_dup duplicate CHROM/POS/REF/ALT keys, $n_dot missing IDs, $n_multi multi-ALT records"
+  [[ "$n_dup" -gt 0 ]] || warn "no duplicate records -- is this the deduplicated copy? The fix is only exercised by the original."
+  [[ "$n_rec" -eq 51910 && "$n_dup" -eq 31 ]] || warn "counts differ from the #93 file (51910 records, 31 duplicates) -- assertions derived from it will say so"
+  if [[ -f "${REFERENCE:-}.fai" ]]; then
+    missing=$(cat_any "$GRAFFITE_VCF" | awk -F'\t' '!/^#/ {print $1}' | sort -u \
+              | comm -23 - <(cut -f1 "${REFERENCE}.fai" | sort -u) | wc -l | tr -d ' ')
+    [[ "$missing" -eq 0 ]] && ok "every VCF contig is in the reference" \
+      || bad "$missing VCF contigs are not in ${REFERENCE}.fai -- wrong reference?"
+  fi
+fi
+
+echo "== reads =="
+for var in READS_1 READS_2; do
+  val="${!var:-}"; [[ -z "$val" || ! -f "$val" ]] && continue
+  first=$(cat_any "$val" 2>/dev/null | head -c1)
+  [[ "$first" == "@" ]] && ok "$var looks like FASTQ" || bad "$var does not start with '@' -- not a FASTQ?"
+done
+
+echo "== container =="
+PROFILE="${PROFILE:-cluster}"
+RUNNER=""
+command -v apptainer   >/dev/null && RUNNER=apptainer
+[[ -z "$RUNNER" ]] && command -v singularity >/dev/null && RUNNER=singularity
+if [[ -n "${GRAFFITE_SIF:-}" ]]; then
+  [[ -f "$GRAFFITE_SIF" ]] && ok "container $GRAFFITE_SIF" || bad "GRAFFITE_SIF=$GRAFFITE_SIF missing"
+  if [[ -n "$RUNNER" && -f "$GRAFFITE_SIF" ]]; then
+    for t in PanGenie PanGenie-index bcftools python3; do
+      "$RUNNER" exec "$GRAFFITE_SIF" which "$t" >/dev/null 2>&1 \
+        && ok "container has $t" || bad "container is missing $t"
+    done
+    "$RUNNER" exec "$GRAFFITE_SIF" python3 -c 'import pyfaidx' >/dev/null 2>&1 \
+      && ok "container python3 has pyfaidx (merge_vcfs.py)" || bad "container python3 lacks pyfaidx"
+  fi
+else
+  warn "GRAFFITE_SIF not set -- Nextflow will pull the container for -profile $PROFILE"
+  [[ -n "$RUNNER" ]] && ok "$RUNNER present" \
+    || warn "no apptainer/singularity on this host -- fine if the compute nodes have it"
+fi
+
+echo "== pipeline revision =="
+PROJECT="${PROJECT:-cgroza/GraffiTE}"
+REVISION="${REVISION:-fix/pangenie-dup-ids-93}"
+GT_DIR="${NXF_ASSETS:-$HOME/.nextflow/assets}/$PROJECT"
+if [[ ! -d "$GT_DIR" ]]; then
+  bad "$GT_DIR not cached -- run ./bootstrap.sh"
+else
+  BR="$(cd "$GT_DIR" && git rev-parse --abbrev-ref HEAD 2>/dev/null || echo '?')"
+  [[ "$BR" == "$REVISION" ]] && ok "cached revision $BR ($(cd "$GT_DIR" && git rev-parse --short HEAD))" \
+    || bad "cached revision is $BR, expected $REVISION -- rerun ./bootstrap.sh"
+  for f in main.nf module/main.nf bin/pangenie_graph_vcf.py bin/merge_vcfs.py test/pangenie_index/test_graph_vcf.sh; do
+    [[ -f "$GT_DIR/$f" ]] && ok "$f" || bad "$GT_DIR/$f missing"
+  done
+  [[ -f "$GT_DIR/panmethyl/module/main.nf" ]] && ok "panmethyl submodule present" \
+    || bad "panmethyl/module/main.nf missing -- the include in main.nf will fail (nextflow pull should fetch submodules)"
+  # The graph-input unit test needs bcftools and pyfaidx. Run it in the
+  # container when one is given, otherwise on the host (it skips itself when
+  # a tool is missing).
+  if [[ -n "$RUNNER" && -f "${GRAFFITE_SIF:-}" ]]; then
+    out=$("$RUNNER" exec "$GRAFFITE_SIF" bash "$GT_DIR/test/pangenie_index/test_graph_vcf.sh" 2>&1); rc=$?
+  else
+    out=$(bash "$GT_DIR/test/pangenie_index/test_graph_vcf.sh" 2>&1); rc=$?
+  fi
+  if [[ "$out" == *"[skip]"* ]]; then warn "graph-input unit test skipped: $(echo "$out" | grep skip | head -1)"
+  elif [[ $rc -eq 0 ]]; then ok "graph-input unit test passes ($(echo "$out" | grep -c '\[ ok \]') checks)"
+  else bad "graph-input unit test FAILED -- do not run the pipeline, report this:"; echo "$out" | grep FAIL; fi
+fi
+
+echo "== nextflow =="
+if command -v nextflow >/dev/null; then
+  NXF_V=$(nextflow -v 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+  ok "nextflow $NXF_V"
+  # Nextflow 26.04 parses with the strict syntax by default; GraffiTE did not
+  # compile under it before this branch. nextflow lint exists from 25.04.
+  if [[ -d "$GT_DIR" ]] && nextflow lint -h >/dev/null 2>&1; then
+    lint=$(cd "$GT_DIR" && nextflow lint -o concise main.nf module/main.nf nextflow.config 2>&1)
+    nerr=$(echo "$lint" | grep -c '^Error')
+    [[ "$nerr" -eq 0 ]] && ok "nextflow lint: 0 errors in main.nf, module/main.nf, nextflow.config" \
+      || { bad "nextflow lint: $nerr errors"; echo "$lint" | grep '^Error' | head -10; }
+  else
+    warn "nextflow lint not available in $NXF_V -- strict-syntax check skipped"
+  fi
+else
+  bad "nextflow not on PATH (module load nextflow?)"
+fi
+
+echo
+[[ $fail -eq 0 ]] && echo "pre-flight PASSED" || echo "pre-flight FAILED -- fix the above before running"
+exit $fail

--- a/test/pangenie_93/handout/run_pangenie_test.sh
+++ b/test/pangenie_93/handout/run_pangenie_test.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# #93 PanGenie test: genotype the reporter's pangenome.vcf with PanGenie,
+# starting from --graffite_vcf (discovery is skipped), then run the assertions.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+[[ -f INPUTS.env ]] || { echo "INPUTS.env not found -- run ./bootstrap.sh first" >&2; exit 1; }
+# shellcheck disable=SC1091
+source ./INPUTS.env
+
+for v in GRAFFITE_VCF REFERENCE READS_1; do
+  [[ -n "${!v:-}" ]] || { echo "$v is empty in INPUTS.env" >&2; exit 1; }
+done
+OUTDIR="${OUTDIR:-pangenie_93_run}"
+PROFILE="${PROFILE:-cluster}"
+CPUS="${CPUS:-16}"
+PANGENIE_MEMORY="${PANGENIE_MEMORY:-120G}"
+PANGENIE_TIME="${PANGENIE_TIME:-24h}"
+SAMPLE_1="${SAMPLE_1:-S1}"
+SAMPLE_2="${SAMPLE_2:-S2}"
+REVISION="${REVISION:-fix/pangenie-dup-ids-93}"
+PROJECT="${PROJECT:-cgroza/GraffiTE}"
+mkdir -p "$OUTDIR"
+OUTDIR_ABS="$(cd "$OUTDIR" && pwd)"
+
+# Two samples so that the run shows pangenie starting once per sample. With no
+# READS_2 the same reads go in twice; GraffiTE sees two samples either way.
+READS_CSV="$OUTDIR_ABS/reads.csv"
+{
+  echo "path,sample,type"
+  echo "${READS_1},${SAMPLE_1},short"
+  echo "${READS_2:-$READS_1},${SAMPLE_2},short"
+} > "$READS_CSV"
+echo "reads    : $READS_CSV"
+sed 's/^/           /' "$READS_CSV"
+
+# Resume safety. Nextflow's task hash does not cover bin/, so after a new
+# commit -resume could reuse a pangenie_index built by the old
+# pangenie_graph_vcf.py. Drop -resume whenever the revision moves.
+ASSET="${NXF_ASSETS:-$HOME/.nextflow/assets}/$PROJECT"
+COMMIT="$(cd "$ASSET" 2>/dev/null && git rev-parse HEAD 2>/dev/null || echo unknown)"
+STAMP="$OUTDIR/.last_commit"
+RESUME_ARG=(-resume)
+if [[ -f "$STAMP" && "$(cat "$STAMP")" != "$COMMIT" ]]; then
+  RESUME_ARG=()
+  echo "!! pipeline moved $(cut -c1-8 "$STAMP") -> ${COMMIT:0:8}: running WITHOUT -resume"
+elif [[ ! -f "$STAMP" && -d "$OUTDIR/4_Genotyping" ]]; then
+  RESUME_ARG=()
+  echo "!! existing output with no revision stamp: running without -resume"
+fi
+
+echo "project  : $PROJECT -r $REVISION (${COMMIT:0:8})"
+echo "nextflow : $(nextflow -v 2>/dev/null | head -1)"
+echo "out      : $OUTDIR"
+
+# -latest re-pulls the branch tip so a fix pushed upstream is picked up.
+nextflow run "$PROJECT" -r "$REVISION" -latest \
+    --graffite_vcf    "$GRAFFITE_VCF" \
+    --reference       "$REFERENCE" \
+    --graph_method    pangenie \
+    --genotype_with   "$READS_CSV" \
+    --cores           "$CPUS" \
+    --pangenie_memory "$PANGENIE_MEMORY" \
+    --pangenie_time   "$PANGENIE_TIME" \
+    --out             "$OUTDIR" \
+    -profile          "$PROFILE" \
+    ${GRAFFITE_SIF:+-with-singularity "$GRAFFITE_SIF"} \
+    -with-report "$OUTDIR/nextflow_report.html" \
+    -with-trace  "$OUTDIR/nextflow_trace.txt" \
+    "${RESUME_ARG[@]}"
+
+echo "$COMMIT" > "$STAMP"
+
+echo
+echo "== assertions =="
+python3 ./assert_pangenie_test.py \
+    --outdir "$OUTDIR" \
+    --graffite-vcf "$GRAFFITE_VCF" \
+    --samples "$SAMPLE_1,$SAMPLE_2" \
+    ${READS_2:+--distinct-reads} \
+  | tee "$OUTDIR/pangenie_93_assertions.log"
+exit "${PIPESTATUS[0]}"

--- a/test/pangenie_index/test_graph_vcf.sh
+++ b/test/pangenie_index/test_graph_vcf.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Regression test for the pangenie_index graph input (#93).
+#
+# merge_vcfs.py raised "An ID needs to be provided for each individual ID"
+# when `bcftools norm -m+` had joined records at one position into a record
+# with a different number of IDs and ALT alleles. That happens with two
+# records of the same CHROM/POS/REF/ALT and different IDs, two records sharing
+# an ID, and a record with ID "." beside another at its position. The test
+# runs the process script, minus PanGenie-index, on those records and checks
+# the tracking table.
+#
+# The fixture also has a record with two ALT alleles, an ID containing ":",
+# three records at one position and a deletion that overlaps an insertion.
+# merge_vcfs.py drops alleles from the last two, and the table must mark
+# them in_graph=no.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+export PATH="$(cd ../../bin && pwd):$PATH"
+
+command -v bcftools >/dev/null || { echo "  [skip] bcftools not on PATH"; exit 0; }
+python3 -c 'import pyfaidx' 2>/dev/null || { echo "  [skip] pyfaidx not importable"; exit 0; }
+
+fail=0
+chk(){ if [[ "$2" == "$3" ]]; then echo "  [ ok ] $1"; else
+       echo "  [FAIL] $1: got '$2', want '$3'"; fail=1; fi; }
+
+tmp=$(mktemp -d); trap 'rm -rf "$tmp"' EXIT
+
+python3 - "$tmp" <<'EOF'
+import random, sys
+tmp = sys.argv[1]
+random.seed(93)
+seq = ''.join(random.choice('ACGT') for _ in range(3000))
+open(f'{tmp}/ref.fa', 'w').write('>chr1\n' + '\n'.join(seq[i:i+60] for i in range(0, len(seq), 60)) + '\n')
+def s(n): return ''.join(random.choice('ACGT') for _ in range(n))
+I1, I2, I3 = s(60), s(70), s(80)
+def ins(pos, vid, *alts):
+    r = seq[pos-1]
+    return f"chr1\t{pos}\t{vid}\t{r}\t{','.join(r + a for a in alts)}\t.\tPASS\tSVTYPE=INS\tGT\t1/1"
+def dl(pos, vid, n):
+    return f"chr1\t{pos}\t{vid}\t{seq[pos-1:pos+n]}\t{seq[pos-1]}\t.\tPASS\tSVTYPE=DEL\tGT\t0/1"
+recs = [
+    ins(100, 'dupA', I1), ins(100, 'dupB', I1),         # 1-2 same allele, two IDs
+    ins(400, 'same', I1), ins(400, 'same', I2),         # 3-4 one ID, two alleles
+    ins(700, '.', I1), ins(700, 'dotmate', I2),         # 5-6 missing ID
+    ins(1000, 'multi', I1, I2),                         # 7   two ALT alleles
+    ins(1300, 'chr1:1300:INS', I1),                     # 8   ID with ':'
+    ins(1600, 't1', I1), ins(1600, 't2', I2), ins(1600, 't3', I3),  # 9-11
+    dl(1900, 'ovDel', 200), ins(2000, 'ovIns', I1),     # 12-13 overlap
+    ins(2500, 'plain', I1),                             # 14
+]
+hdr = ['##fileformat=VCFv4.2', '##contig=<ID=chr1,length=3000>',
+       '##INFO=<ID=SVTYPE,Number=1,Type=String,Description="type">',
+       '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
+       '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tS1']
+open(f'{tmp}/pangenome.vcf', 'w').write('\n'.join(hdr + recs) + '\n')
+EOF
+
+cd "$tmp"
+# A copy of the pangenie_index script in module/main.nf, minus PanGenie-index.
+# Keep the two in step.
+bcftools view -G -Ov -o sites.vcf pangenome.vcf
+pangenie_graph_vcf.py prepare sites.vcf graph_input.vcf pangenie_graph_variants.tsv 2> prepare.log
+bcftools sort graph_input.vcf 2>/dev/null | bcftools norm -m+ -Ov -o graph.vcf 2>/dev/null
+# merge_vcfs.py names /usr/bin/python3, which may not be the python3 that has pyfaidx.
+rc=0; python3 "$(command -v merge_vcfs.py)" merge -r ref.fa -v graph.vcf -ploidy 2 > graph_merged.vcf 2> merge.log || rc=$?
+chk "merge_vcfs.py exits 0" "$rc" "0"
+pangenie_graph_vcf.py report pangenie_graph_variants.tsv graph_merged.vcf 2> report.log
+
+row(){ awk -F'\t' -v r="$1" -v a="${2:-1}" '$1==r && $5==a {print $6, $7, $8}' pangenie_graph_variants.tsv; }
+chk "one row per ALT allele"          "$(tail -n +2 pangenie_graph_variants.tsv | wc -l | tr -d ' ')" "15"
+chk "first of a duplicate pair"       "$(row 1)" "dupA yes ."
+chk "second of a duplicate pair"      "$(row 2)" "dupA yes duplicate_of_record_1"
+chk "shared ID, first"                "$(row 3)" "same yes ."
+chk "shared ID, second renamed"       "$(row 4)" "graffite_rec4 yes id_replaced"
+chk "missing ID renamed"              "$(row 5)" "graffite_rec5 yes id_replaced"
+chk "multi-ALT, allele 2"             "$(row 7 2)" "graffite_rec7_2 yes id_replaced"
+chk "ID with ':' renamed"             "$(row 8)" "graffite_rec8 yes id_replaced"
+# Which of the three is left out depends on the ALT order bcftools norm writes.
+chk "three alleles at one position"   "$(for r in 9 10 11; do row $r; done | awk '$2=="no"' | wc -l | tr -d ' ')" "1"
+chk "overlapping deletion"            "$(row 12)" "ovDel no ."
+chk "overlapping insertion"           "$(row 13)" "ovIns no ."
+chk "plain record keeps its ID"       "$(row 14)" "plain yes ."
+chk "report counts"                   "$(cat report.log)" \
+    "pangenie_graph_vcf.py: 3 of 15 pangenome.vcf alleles are not in the PanGenie graph and get no genotype"
+
+# The graph IDs marked in_graph=yes are the same set as the IDs in INFO/ID of
+# the graph, which PanGenie copies to the genotyped VCFs.
+ids=$(grep -v '^#' graph_merged.vcf | cut -f8 | sed 's/.*ID=//' | tr ',:' '\n\n' | sort -u)
+want=$(awk -F'\t' 'NR>1 && $7=="yes" {print $6}' pangenie_graph_variants.tsv | sort -u)
+chk "table matches graph INFO/ID"     "$ids" "$want"
+
+exit $fail

--- a/test/truvari_merge/test_multi_input.sh
+++ b/test/truvari_merge/test_multi_input.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Regression test for truvari_merge with more than one input VCF.
+#
+# The sharded collapse (e477ec1) wrote truvari_merged.vcf.gz, but the next
+# line still read truvari_merged.vcf, so a run that reached truvari_merge
+# with two or more VCFs failed there with "Failed to open file". The test
+# takes the script straight from module/main.nf, runs it on two svim-asm
+# style VCFs and checks SVs.vcf.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+here=$PWD
+module="$here/../../module/main.nf"
+export PATH="$(cd ../../bin && pwd):$PATH"
+
+for t in bcftools bgzip tabix truvari; do
+  command -v $t >/dev/null || { echo "  [skip] $t not on PATH"; exit 0; }
+done
+python3 -c 'import vcfpy' 2>/dev/null || { echo "  [skip] vcfpy not importable"; exit 0; }
+
+fail=0
+chk(){ if [[ "$2" == "$3" ]]; then echo "  [ ok ] $1"; else
+       echo "  [FAIL] $1: got '$2', want '$3'"; fail=1; fi; }
+
+tmp=$(mktemp -d); trap 'rm -rf "$tmp"' EXIT
+cd "$tmp"
+
+# shorten_ids.py names /usr/bin/python3, which may not be the python3 that
+# has vcfpy. The script calls it by name, so a shim first on PATH redirects it.
+mkdir shim
+printf '#!/usr/bin/env bash\nexec python3 %s "$@"\n' "$(command -v shorten_ids.py)" > shim/shorten_ids.py
+chmod +x shim/shorten_ids.py
+export PATH="$tmp/shim:$PATH"
+
+python3 - "$module" <<'EOF'
+import random, re, sys
+random.seed(3)
+seq = ''.join(random.choice('ACGT') for _ in range(20000))
+open('ref.fa', 'w').write('>chr1\n' + '\n'.join(seq[i:i+60] for i in range(0, len(seq), 60)) + '\n')
+def s(n): return ''.join(random.choice('ACGT') for _ in range(n))
+shared, a_only, b_only = s(300), s(250), s(400)
+def hdr(name):
+    return ['##fileformat=VCFv4.2', '##contig=<ID=chr1,length=20000>',
+            '##INFO=<ID=SVTYPE,Number=1,Type=String,Description="type">',
+            '##INFO=<ID=SVLEN,Number=1,Type=Integer,Description="length">',
+            '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
+            '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t' + name]
+def ins(p, i, x): return f"chr1\t{p}\t{i}\t{seq[p-1]}\t{seq[p-1]+x}\t.\tPASS\tSVTYPE=INS;SVLEN={len(x)}\tGT\t1/1"
+def dl(p, i, n): return f"chr1\t{p}\t{i}\t{seq[p-1:p+n]}\t{seq[p-1]}\t.\tPASS\tSVTYPE=DEL;SVLEN=-{n}\tGT\t1/1"
+# The two insertions near 1000 differ by 2 bp of position and 3 bp of length,
+# so truvari collapses them; the deletions are identical.
+open('A.vcf', 'w').write('\n'.join(hdr('A') + [ins(1000, 'A.INS.1', shared), ins(5000, 'A.INS.2', a_only), dl(9000, 'A.DEL.1', 500)]) + '\n')
+open('B.vcf', 'w').write('\n'.join(hdr('B') + [ins(1002, 'B.INS.1', shared[:-3]), ins(15000, 'B.INS.2', b_only), dl(9000, 'B.DEL.1', 500)]) + '\n')
+
+# Nextflow's interpolation, done by hand for this process.
+body = re.search(r'process truvari_merge \{.*?script:\n  """\n(.*?)\n  """', open(sys.argv[1]).read(), re.S).group(1)
+body = (body.replace('\\$', '$').replace('${vcfs}', 'A.vcf.gz B.vcf.gz')
+            .replace('${task.cpus}', '2').replace('${ref}', 'ref.fa').replace('${from_vcf}', 'false'))
+open('truvari_merge.sh', 'w').write(body)
+EOF
+for s in A B; do bcftools sort -Oz -o $s.vcf.gz $s.vcf 2>/dev/null; done
+
+# BSD xargs gives -I replacements 255 bytes by default, and this command is
+# longer. Where xargs is not GNU (macOS), the shards run one after the other.
+if ! xargs --version >/dev/null 2>&1; then
+  python3 - <<'EOF'
+b = open('truvari_merge.sh').read()
+b = b.replace('xargs -P "2" -I{} bash -c \'', 'while read -r s; do bash -c \'').replace('shard="{}"', 'shard="$1"')
+b = b.replace('rm "collapsed/${base}.vcf"\n    \'\n', 'rm "collapsed/${base}.vcf"\n    \' _ "$s"; done\n')
+open('truvari_merge.sh', 'w').write(b)
+EOF
+fi
+
+rc=0; bash -ue truvari_merge.sh > run.log 2>&1 || rc=$?
+chk "script exits 0" "$rc" "0"
+[[ -f SVs.vcf ]] || { echo "  [FAIL] no SVs.vcf"; tail -5 run.log; exit 1; }
+chk "records after collapse"   "$(bcftools view -H SVs.vcf | wc -l | tr -d ' ')" "4"
+chk "collapsed insertion, both genotypes" "$(bcftools view -H SVs.vcf | awk '$2==1000' | cut -f10,11)" "1/1	1/1"
+chk "missing GT set to 0/0"    "$(bcftools view -H SVs.vcf | awk '$2==5000' | cut -f10,11)" "1/1	0/0"
+chk "SVLEN filled"             "$(bcftools view -H SVs.vcf | awk '$2==15000' | grep -o 'SVLEN=[-0-9]*')" "SVLEN=400"
+chk "IDs shortened and unique" "$(bcftools view -H SVs.vcf | cut -f3 | sort -u | wc -l | tr -d ' ')" "4"
+
+exit $fail


### PR DESCRIPTION
Closes #93.

## The two bugs in #93

**`pangenie_index` died in `merge_vcfs.py`** with `An ID needs to be provided for each individual ID`. That script wants one ID per ALT allele, and `bcftools norm -m+` can hand it a record where the two counts differ. norm joins two records with the same CHROM/POS/REF/ALT and different IDs into one ALT carrying both IDs, keeps one ID for two ALTs when two records share an ID, and drops an ID of `.` beside another record at the same position. With one assembly or with `--vcf`, `truvari_merge` copies the caller's VCF through without collapsing records or rewriting IDs, so such records reach `pangenome.vcf`. The reporter's file holds 31 pairs of the first kind, each from two consecutive svim-asm calls.

**Only one sample was genotyped.** `pangenie` took the reference as a second input straight from `Channel.fromPath`, which is a queue channel with one item, so Nextflow started one task and the other samples never ran. This came in with bbb22a3, so every PanGenie run with more than one sample hit it.

## Two more found on the way

**`truvari_merge` failed with two or more VCFs.** The sharded collapse (e477ec1) writes `truvari_merged.vcf.gz`, and the next line still read `truvari_merged.vcf`. Any run reaching that branch stopped there with `Failed to open file`.

**The workflow did not compile under Nextflow 26.** 26.04 parses with the strict syntax by default and stopped at `main.nf:129`. The strict parser rejected statements outside the workflow, trailing dots in method chains, a Java-style lambda, three `switch` statements, closures called like functions, and a process with no `script:` label. All are fixed. `repeatmask_VCF` also read `task.index` in `publishDir` outside a closure, which the strict parser evaluates before any task exists; that one surfaced at run time rather than at compile time. 25.10 and earlier still parse the old code, so this is only for people on 26.

## Tracking pangenome.vcf through to the genotypes

`bin/pangenie_graph_vcf.py` builds the graph input now. It makes one graph variant of records that share CHROM/POS/REF/ALT, and replaces an ID that is missing, already used, or holds a character `merge_vcfs.py` or PanGenie splits on. `pangenome.vcf` itself does not change.

Because that step can merge two records into one, it also writes `4_Genotyping/pangenie_graph_variants.tsv`, one row per ALT allele of `pangenome.vcf`:

```
record  CHROM        POS        pangenome_ID                  allele  graph_ID                      in_graph  note
2171    NC_072473.1  119645481  EptFus1.0.svim_asm.DEL.1780   1       EptFus1.0.svim_asm.DEL.1780   yes       .
2172    NC_072473.1  119645481  EptFus1.0.svim_asm.DEL.1781   1       EptFus1.0.svim_asm.DEL.1780   yes       duplicate_of_record_2171
```

PanGenie copies `graph_ID` to `INFO/ID` of the genotyped VCFs, so you can follow a record of `pangenome.vcf` to its genotype through the table, even when two records collapsed into one or when the graph left the allele out.

The table also exposes something that predates this PR: `merge_vcfs.py` drops alleles that overlap another allele, all but two ALT alleles at one position, and alleles holding a base other than A, C, G or T. On the reporter's file that is 1,569 of 51,910 alleles, 1,550 of them holding `N` in the ALT. Before this PR, `merge_vcfs.py` reported only the 9 overlap clusters, on stderr. They are now `in_graph=no`. Fixing the dropping itself is separate work.

## Verification

An end-to-end run on the reporter's `pangenome.vcf` (51,910 records, duplicates left in) against the EptFus1.0 reference, on Puma with the container, Nextflow 25.10.0, 24 threads, at commit cd74f98:

- `pangenie_index` completed (6m15s, 24.2 GB) where it used to fail, and `PanGenie-index` built a graph of 50,274 records
- **two** `pangenie` tasks ran, one per sample, and `4_Genotyping` holds both VCFs
- one table row per ALT allele; 31 duplicate rows, each carrying the graph ID of its first occurrence
- the graph IDs in `INFO/ID` of each per-sample VCF and of the merged VCF are exactly the 50,310 `in_graph=yes` IDs of the table
- all 50,310 records of the merged VCF carry an ID column that the table maps back to their `graph_ID`
- `in_graph=no` came out at 1,569, the number predicted beforehand from a local run against a stand-in reference

The reads were simulated at 3x from the reference, so the genotypes carry nothing about accuracy: 50,302 of 50,310 records come back `0/0` in both samples, which is what reference reads give. This run covers the plumbing.

Also in the repo:

- `test/pangenie_index/test_graph_vcf.sh`, 15 checks over every record shape that made `merge_vcfs.py` raise, plus multi-ALT records, an ID holding `:`, three records at one position and overlapping SVs. The old script fails it with the error from #93.
- `test/truvari_merge/test_multi_input.sh`, which lifts the process script out of `module/main.nf` and runs it on two svim-asm style VCFs with truvari 5.4.0. The old line exits 255.
- `test/pangenie_93/handout/`, the HPC handout that produced the run above.

`nextflow lint` reports no errors on `main.nf`, `module/main.nf` and `nextflow.config` under 26.04.6. `-preview` passes for `--graffite_vcf` with pangenie, `--assemblies` with giraffe and `--RM_dir` with `--human`, under 26.04.6 with both parsers and under 24.10.5. The HPC run used 25.10.0, which still parses the old code, so it did not exercise the Nextflow 26 work. 23.10 was not tried.

## Known gaps

- `truvari_merge` with two or more VCFs was checked with the process script run by hand, not through a pipeline run.
- 21 `nextflow lint` deprecation warnings remain (`Channel` for `channel`, implicit closure parameters). 26.04 does not treat them as errors.
- `panmethyl/main.nf` has lint errors of its own. GraffiTE never loads it, and it lives in the submodule's repository.
- Where `pangenome.vcf` carries its own `INFO/ID`, which a single PAV VCF does, `merge_VCFs` would overwrite PanGenie's `INFO/ID` in the merged VCF and the table would only connect through the per-sample VCFs. Not tested.

## Merging beside #99

#99 touches `make_graph` and `graph_align_reads` too. The `if/else` rewrites here already carry its changes to those blocks (9b77788 and b6a9487), so whichever merges second can take this branch's version of them. #99 also adds a top-level `if(...) error` for the panmethyl submodule, which the strict syntax should reject in the same way. I have not tried it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LY467TiviQf8FLdyP4L3r8
